### PR TITLE
Flatten cloned images of snapshot during snapshot deletion

### DIFF
--- a/api/image.go
+++ b/api/image.go
@@ -28,12 +28,12 @@ const (
 )
 
 type ImageSpec struct {
-	Size        uint64         `json:"size"`
-	WWN         string         `json:"wwn"`
-	Limits      Limits         `json:"limits"`
-	Image       string         `json:"image"`
-	SnapshotRef *string        `json:"snapshotRef"`
-	Encryption  EncryptionSpec `json:"encryption"`
+	Size        uint64          `json:"size"`
+	WWN         string          `json:"wwn"`
+	Limits      Limits          `json:"limits"`
+	Image       string          `json:"image"`
+	SnapshotRef *string         `json:"snapshotRef"`
+	Encryption  *EncryptionSpec `json:"encryption"`
 }
 
 type EncryptionType string

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -41,7 +41,7 @@ func getSnapshotSourceDetails(snapshot *providerapi.Snapshot) (parentName string
 }
 
 func closeImage(log logr.Logger, img *librbd.Image) {
-	if closeErr := img.Close(); closeErr != nil {
+	if closeErr := img.Close(); closeErr != nil && closeErr != librbd.ErrImageNotOpen {
 		log.Error(closeErr, "failed to close image")
 	}
 }

--- a/internal/volumeserver/volume_list.go
+++ b/internal/volumeserver/volume_list.go
@@ -8,14 +8,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"github.com/ironcore-dev/ceph-provider/api"
 	"github.com/ironcore-dev/ceph-provider/internal/utils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func (s *Server) getIriVolume(ctx context.Context, log logr.Logger, imageId string) (*iri.Volume, error) {
+func (s *Server) getIriVolume(ctx context.Context, imageId string) (*iri.Volume, error) {
 	cephImage, err := s.imageStore.Get(ctx, imageId)
 	if err != nil {
 		if errors.Is(err, utils.ErrVolumeNotFound) {
@@ -50,7 +49,7 @@ func (s *Server) filterVolumes(volumes []*iri.Volume, filter *iri.VolumeFilter) 
 	return res
 }
 
-func (s *Server) listVolumes(ctx context.Context, log logr.Logger) ([]*iri.Volume, error) {
+func (s *Server) listVolumes(ctx context.Context) ([]*iri.Volume, error) {
 	cephImages, err := s.imageStore.List(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error listing volumes: %w", err)
@@ -77,7 +76,7 @@ func (s *Server) ListVolumes(ctx context.Context, req *iri.ListVolumesRequest) (
 	log.V(2).Info("Listing volumes")
 
 	if filter := req.Filter; filter != nil && filter.Id != "" {
-		volume, err := s.getIriVolume(ctx, log, filter.Id)
+		volume, err := s.getIriVolume(ctx, filter.Id)
 		if err != nil {
 			if !errors.Is(err, utils.ErrVolumeNotFound) && !errors.Is(err, utils.ErrVolumeIsntManaged) {
 				return nil, utils.ConvertInternalErrorToGRPC(err)
@@ -92,7 +91,7 @@ func (s *Server) ListVolumes(ctx context.Context, req *iri.ListVolumesRequest) (
 		}, nil
 	}
 
-	volumes, err := s.listVolumes(ctx, log)
+	volumes, err := s.listVolumes(ctx)
 	if err != nil {
 		return nil, utils.ConvertInternalErrorToGRPC(err)
 	}

--- a/internal/volumeserver/volumesnapshot_list.go
+++ b/internal/volumeserver/volumesnapshot_list.go
@@ -48,7 +48,7 @@ func (s *Server) filterSnapshot(snapshots []*iri.VolumeSnapshot, filter *iri.Vol
 	return res
 }
 
-func (s *Server) listSnapshots(ctx context.Context, log logr.Logger) ([]*iri.VolumeSnapshot, error) {
+func (s *Server) listSnapshots(ctx context.Context) ([]*iri.VolumeSnapshot, error) {
 	cephSnapshots, err := s.snapshotStore.List(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error listing snapshots: %w", err)
@@ -90,7 +90,7 @@ func (s *Server) ListVolumeSnapshots(ctx context.Context, req *iri.ListVolumeSna
 		}, nil
 	}
 
-	snapshots, err := s.listSnapshots(ctx, log)
+	snapshots, err := s.listSnapshots(ctx)
 	if err != nil {
 		return nil, utils.ConvertInternalErrorToGRPC(err)
 	}


### PR DESCRIPTION
# Proposed Changes

- Flatten cloned images of snapshot while deleting snapshot
- Delete volume only if it has no snapshot.
- Delete volume os-image only if it is not referenced by any other volumes
- Improve error handling in `CreateVolume()`

Fixes #809 