### PR TITLE
Clone snapshots and flatten rbd images before deletion

### DIFF
--- a/api/image.go
+++ b/api/image.go
@@ -28,12 +28,12 @@ const (
 )
 
 type ImageSpec struct {
-	Size        uint64         `json:"size"`
-	WWN         string         `json:"wwn"`
-	Limits      Limits         `json:"limits"`
-	Image       string         `json:"image"`
-	SnapshotRef *string        `json:"snapshotRef"`
-	Encryption  EncryptionSpec `json:"encryption"`
+	Size        uint64          `json:"size"`
+	WWN         string          `json:"wwn"`
+	Limits      Limits          `json:"limits"`
+	Image       string          `json:"image"`
+	SnapshotRef *string         `json:"snapshotRef"`
+	Encryption  *EncryptionSpec `json:"encryption"`
 }
 
 type EncryptionType string

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/rook/rook/pkg/apis v0.0.0-20250716205136-e4da184ce30a
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.18.0
 	google.golang.org/grpc v1.77.0
 	k8s.io/api v0.33.4
@@ -123,7 +124,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.29.0 // indirect

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -43,7 +43,7 @@ func getSnapshotSourceDetails(snapshot *providerapi.Snapshot) (parentName string
 }
 
 func closeImage(log logr.Logger, img *librbd.Image) {
-	if closeErr := img.Close(); closeErr != nil && closeErr != librbd.ErrImageNotOpen {
+	if closeErr := img.Close(); closeErr != nil && errors.Is(closeErr, librbd.ErrImageNotOpen) {
 		log.Error(closeErr, "failed to close image")
 	}
 }
@@ -137,7 +137,7 @@ func flattenChildImages(log logr.Logger, conn *rados.Conn, img *librbd.Image) er
 	return nil
 }
 
-func isSnapshotExist(log logr.Logger, ioCtx *rados.IOContext, imageName string, snapshotName string) bool {
+func snapshotExists(log logr.Logger, ioCtx *rados.IOContext, imageName string, snapshotName string) bool {
 	img, err := openImage(ioCtx, imageName)
 	if err != nil {
 		return false

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -4,8 +4,10 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/ceph/go-ceph/rados"
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/go-logr/logr"
 	providerapi "github.com/ironcore-dev/ceph-provider/api"
@@ -44,4 +46,92 @@ func closeImage(log logr.Logger, img *librbd.Image) {
 	if closeErr := img.Close(); closeErr != nil && closeErr != librbd.ErrImageNotOpen {
 		log.Error(closeErr, "failed to close image")
 	}
+}
+
+func openImage(ioCtx *rados.IOContext, imageName string) (*librbd.Image, error) {
+	img, err := librbd.OpenImage(ioCtx, imageName, librbd.NoSnapshot)
+	if err != nil {
+		if !errors.Is(err, librbd.ErrNotFound) {
+			return nil, fmt.Errorf("failed to open cloned image: %w", err)
+		}
+		return nil, err
+	}
+	return img, nil
+}
+
+func flattenImage(log logr.Logger, ioCtx *rados.IOContext, imageName string) error {
+	log.V(2).Info("Flatten cloned image", "ImageID", imageName)
+	img, err := openImage(ioCtx, imageName)
+	if err != nil {
+		return err
+	}
+	defer closeImage(log, img)
+
+	if err := img.Flatten(); err != nil {
+		return fmt.Errorf("failed to flatten cloned image: %w", err)
+	}
+	log.V(2).Info("Flattened cloned image", "ImageID", imageName)
+	return nil
+}
+
+func createSnapshot(log logr.Logger, ioCtx *rados.IOContext, snapshotName string, imageName string) error {
+	img, err := openImage(ioCtx, imageName)
+	if err != nil {
+		return err
+	}
+	defer closeImage(log, img)
+
+	imgSnap, err := img.CreateSnapshot(snapshotName)
+	if err != nil {
+		return fmt.Errorf("unable to create snapshot: %w", err)
+	}
+	log.Info("snapshot created")
+
+	if err := imgSnap.Protect(); err != nil {
+		return fmt.Errorf("unable to protect snapshot: %w", err)
+	}
+
+	if err := img.SetSnapshot(snapshotName); err != nil {
+		return fmt.Errorf("failed to set snapshot %s for image %s: %w", snapshotName, img.GetName(), err)
+	}
+	return nil
+}
+
+func removeSnapshot(snapshot *librbd.Snapshot) error {
+	isProtected, err := snapshot.IsProtected()
+	if err != nil {
+		return fmt.Errorf("unable to chek if snapshot is protected: %w", err)
+	}
+
+	if isProtected {
+		if err := snapshot.Unprotect(); err != nil {
+			return fmt.Errorf("unable to unprotect snapshot: %w", err)
+		}
+	}
+
+	if err := snapshot.Remove(); err != nil {
+		return fmt.Errorf("unable to remove snapshot: %w", err)
+	}
+	return nil
+}
+
+func flattenClildImagesIfAny(log logr.Logger, ioCtx *rados.IOContext, imageName string) error {
+	img, err := openImage(ioCtx, imageName)
+	if err != nil {
+		return err
+	}
+	defer closeImage(log, img)
+
+	pools, childImgs, err := img.ListChildren()
+	if err != nil {
+		return fmt.Errorf("unable to list children: %w", err)
+	}
+	log.V(2).Info("Snapshot references", "pools", len(pools), "rbd-images", len(childImgs))
+
+	for _, snapChildImgName := range childImgs {
+		if err := flattenImage(log, ioCtx, snapChildImgName); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -60,7 +60,7 @@ func openImage(ioCtx *rados.IOContext, imageName string) (*librbd.Image, error) 
 }
 
 func flattenImage(log logr.Logger, ioCtx *rados.IOContext, imageName string) error {
-	log.V(2).Info("Flatten cloned image", "ImageID", imageName)
+	log.V(2).Info("Flatten cloned image", "clonedImageId", imageName)
 	img, err := openImage(ioCtx, imageName)
 	if err != nil {
 		return err
@@ -70,7 +70,7 @@ func flattenImage(log logr.Logger, ioCtx *rados.IOContext, imageName string) err
 	if err := img.Flatten(); err != nil {
 		return fmt.Errorf("failed to flatten cloned image: %w", err)
 	}
-	log.V(2).Info("Flattened cloned image", "ImageID", imageName)
+	log.V(2).Info("Flattened cloned image", "clonedImageId", imageName)
 	return nil
 }
 
@@ -100,7 +100,7 @@ func createSnapshot(log logr.Logger, ioCtx *rados.IOContext, snapshotName string
 func removeSnapshot(snapshot *librbd.Snapshot) error {
 	isProtected, err := snapshot.IsProtected()
 	if err != nil {
-		return fmt.Errorf("unable to chek if snapshot is protected: %w", err)
+		return fmt.Errorf("unable to check if snapshot is protected: %w", err)
 	}
 
 	if isProtected {
@@ -115,13 +115,7 @@ func removeSnapshot(snapshot *librbd.Snapshot) error {
 	return nil
 }
 
-func flattenClildImagesIfAny(log logr.Logger, ioCtx *rados.IOContext, imageName string) error {
-	img, err := openImage(ioCtx, imageName)
-	if err != nil {
-		return err
-	}
-	defer closeImage(log, img)
-
+func flattenChildImagesIfAny(log logr.Logger, ioCtx *rados.IOContext, img *librbd.Image) error {
 	pools, childImgs, err := img.ListChildren()
 	if err != nil {
 		return fmt.Errorf("unable to list children: %w", err)

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -41,7 +41,7 @@ func getSnapshotSourceDetails(snapshot *providerapi.Snapshot) (parentName string
 }
 
 func closeImage(log logr.Logger, img *librbd.Image) {
-	if closeErr := img.Close(); closeErr != nil {
+	if closeErr := img.Close(); closeErr != nil && closeErr != librbd.ErrImageNotOpen {
 		log.Error(closeErr, "failed to close image")
 	}
 }

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -355,17 +355,21 @@ func (r *ImageReconciler) cloneSnapshot(ctx context.Context, log logr.Logger, io
 		},
 	}
 
-	options := librbd.NewRbdImageOptions()
-	defer options.Destroy()
-	if err := options.SetString(librbd.ImageOptionDataPool, r.pool); err != nil {
-		return fmt.Errorf("failed to set data pool: %w", err)
-	}
+	if !rbdExists {
+		options := librbd.NewRbdImageOptions()
+		defer options.Destroy()
+		if err := options.SetString(librbd.ImageOptionDataPool, r.pool); err != nil {
+			return fmt.Errorf("failed to set data pool: %w", err)
+		}
 
-	log.V(2).Info("Creating image from snapshot", "snapshotId", snapName)
-	if ok, err := r.createImageFromSnapshot(ctx, log, ioCtx, clonedImage, snapName, options); err != nil {
-		return fmt.Errorf("failed to create image from snapshot: %w", err)
-	} else if !ok {
-		return nil
+		log.V(2).Info("Creating image from snapshot", "snapshotId", snapName)
+		if ok, err := r.createImageFromSnapshot(ctx, log, ioCtx, clonedImage, snapName, options); err != nil {
+			return fmt.Errorf("failed to create image from snapshot: %w", err)
+		} else if !ok {
+			return nil
+		}
+	} else {
+		log.V(2).Info("Rbd image for snapshot clone already exists")
 	}
 
 	log.V(2).Info("Setting parent image metadata to cloned image")

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -275,15 +275,15 @@ func (r *ImageReconciler) deleteImageSnapshots(ctx context.Context, log logr.Log
 			return fmt.Errorf("snapshot value is nil for %s", snapName)
 		}
 
-		if err := flattenClildImagesIfAny(log, ioCtx, ImageIDToRBDID(image.ID)); err != nil {
-			return fmt.Errorf("failed to flatten snapshot child images")
+		if err := flattenChildImagesIfAny(log, ioCtx, img); err != nil {
+			return fmt.Errorf("failed to flatten snapshot child images: %w", err)
 		}
 
-		log.V(2).Info("Create snapshot clone", "SnapshotId", snapName)
+		log.V(2).Info("Create snapshot clone", "snapshotId", snapName)
 		if err := r.cloneImageFromSnapshot(ctx, log, ioCtx, snapName, image); err != nil {
 			return fmt.Errorf("failed to create snapshot clone: %w", err)
 		}
-		log.V(2).Info("Created snapshot clone", "SnapshotId", snapName)
+		log.V(2).Info("Created snapshot clone", "snapshotId", snapName)
 
 		if err := r.deleteImageSnapshot(ctx, log, ioCtx, snapName, snap); err != nil {
 			return fmt.Errorf("failed to delete image snapshot: %w", err)
@@ -312,7 +312,7 @@ func (r *ImageReconciler) cloneImageFromSnapshot(ctx context.Context, log logr.L
 		},
 	}
 
-	log.V(2).Info("Creating image from snapshot", "snapshotID", clonedImageName)
+	log.V(2).Info("Creating image from snapshot", "snapshotId", clonedImageName)
 	_, err := r.createImageFromSnapshot(ctx, log, ioCtx, clonedImage, clonedImageName, options)
 	if err != nil {
 		return fmt.Errorf("failed to create image from snapshot: %w", err)
@@ -340,7 +340,7 @@ func (r *ImageReconciler) deleteImageSnapshot(ctx context.Context, log logr.Logg
 		return err
 	}
 
-	log.V(2).Info("Create snapshot of cloned image", "ClonedImagetId", snapName)
+	log.V(2).Info("Create snapshot of cloned image", "clonedImageId", snapName)
 	if err := createSnapshot(log, ioCtx, snapName, ImageIDToRBDID(snapName)); err != nil {
 		return fmt.Errorf("failed to create snapshot of cloned image: %w", err)
 	}
@@ -362,7 +362,7 @@ func (r *ImageReconciler) deleteImageSnapshot(ctx context.Context, log logr.Logg
 		}
 	}()
 
-	log.V(2).Info("Remove snapshot", "SnapshotId", snapName)
+	log.V(2).Info("Remove snapshot", "snapshotId", snapName)
 	if err := removeSnapshot(snap); err != nil {
 		return err
 	}

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -272,6 +272,7 @@ func (r *ImageReconciler) deleteImageSnapshots(ctx context.Context, log logr.Log
 	for _, snapInfo := range snaps {
 		snapName := snapInfo.Name
 		log.V(2).Info("Create snapshot clone", "snapshotId", snapName)
+		// cloned image name will be same as snapshot name
 		if err := r.cloneSnapshot(ctx, log, ioCtx, snapName, image); err != nil {
 			return fmt.Errorf("failed to create snapshot clone: %w", err)
 		}
@@ -290,7 +291,7 @@ func (r *ImageReconciler) deleteImageSnapshots(ctx context.Context, log logr.Log
 		}
 	}
 
-	// flatten all child images of snapshot
+	// flatten all child images of the original image's snapshots
 	if err := flattenChildImages(log, r.conn, img); err != nil {
 		return fmt.Errorf("failed to flatten snapshot child images: %w", err)
 	}

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -185,8 +185,8 @@ func (r *SnapshotReconciler) deleteSnapshot(ctx context.Context, log logr.Logger
 	}
 	defer closeImage(log, img)
 
-	if err := flattenClildImagesIfAny(log, ioCtx, img.GetName()); err != nil {
-		return fmt.Errorf("failed to flatten snapshot child images")
+	if err := flattenChildImagesIfAny(log, ioCtx, img); err != nil {
+		return fmt.Errorf("failed to flatten snapshot child images: %w", err)
 	}
 
 	rbdSnapshot := img.GetSnapshot(snapshotID)

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -236,7 +236,7 @@ func (r *SnapshotReconciler) deleteSnapshot(ctx context.Context, log logr.Logger
 		return fmt.Errorf("failed to remove snapshot: %w", err)
 	}
 
-	if snapshot.Source.IronCoreImage != "" {
+	if snapshot.Source.IronCoreImage != "" || rbdID == snapshotID {
 		log.V(2).Info("Remove ironcore os-image")
 		if err := img.Close(); err != nil {
 			return fmt.Errorf("unable to close snapshot: %w", err)

--- a/internal/volumeserver/volume.go
+++ b/internal/volumeserver/volume.go
@@ -96,7 +96,7 @@ func (s *Server) getIriVolumeSpec(image *api.Image) (*iri.VolumeSpec, error) {
 
 	class, ok := api.GetClassLabelFromObject(image)
 	if !ok {
-		return nil, fmt.Errorf("failed to get volume class")
+		return nil, fmt.Errorf("failed to get volume class for image: %s", image.ID)
 	}
 	spec.Class = class
 

--- a/internal/volumeserver/volume_create.go
+++ b/internal/volumeserver/volume_create.go
@@ -78,11 +78,11 @@ func (s *Server) createImageFromVolume(ctx context.Context, log logr.Logger, vol
 				return nil, fmt.Errorf("failed to get snapshot source volume from store: %w", err)
 			}
 
-			log.V(2).Info("Getting image size and encryption from snapshot source volume", "snapshotSourceVolumeID", snapshotSourceVolume.ID)
 			snapshotSize := snapshotSourceVolume.Spec.Size
 			// Validate and determine final size
 			if imageSize == 0 {
 				// No size specified by user, use snapshot size
+				log.V(2).Info("Getting image size from snapshot source volume", "snapshotSourceVolumeID", snapshotSourceVolume.ID)
 				imageSize = snapshotSize
 			} else if imageSize < snapshotSize {
 				// User specified size is too small

--- a/internal/volumeserver/volume_create.go
+++ b/internal/volumeserver/volume_create.go
@@ -88,12 +88,6 @@ func (s *Server) createImageFromVolume(ctx context.Context, log logr.Logger, vol
 				// User specified size is too small
 				return nil, fmt.Errorf("requested size (%d bytes) must not be smaller than snapshot restore size (%d bytes)", imageSize, snapshotSize)
 			}
-			if snapshotSourceVolume.Spec.Encryption != nil {
-				if encryptionSpec != nil {
-					log.V(2).Info("Overriding user-provided encryption with snapshot source encryption")
-				}
-				encryptionSpec = snapshotSourceVolume.Spec.Encryption
-			}
 
 		case dataSource.ImageDataSource != nil:
 			volImage = dataSource.ImageDataSource.Image

--- a/internal/volumeserver/volume_create.go
+++ b/internal/volumeserver/volume_create.go
@@ -89,6 +89,9 @@ func (s *Server) createImageFromVolume(ctx context.Context, log logr.Logger, vol
 				return nil, fmt.Errorf("requested size (%d bytes) must not be smaller than snapshot restore size (%d bytes)", imageSize, snapshotSize)
 			}
 			if snapshotSourceVolume.Spec.Encryption != nil {
+				if encryptionSpec != nil {
+					log.V(2).Info("Overriding user-provided encryption with snapshot source encryption")
+				}
 				encryptionSpec = snapshotSourceVolume.Spec.Encryption
 			}
 
@@ -97,6 +100,9 @@ func (s *Server) createImageFromVolume(ctx context.Context, log logr.Logger, vol
 			log.V(2).Info("Getting image data source", "imageID", volImage)
 			if volImage == "" {
 				return nil, fmt.Errorf("must specify image url in image data source")
+			}
+			if imageSize == 0 {
+				return nil, fmt.Errorf("must specify size when creating volume from image data source")
 			}
 
 		default:

--- a/internal/volumeserver/volume_list.go
+++ b/internal/volumeserver/volume_list.go
@@ -8,14 +8,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"github.com/ironcore-dev/ceph-provider/api"
 	"github.com/ironcore-dev/ceph-provider/internal/utils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func (s *Server) getIriVolume(ctx context.Context, log logr.Logger, imageId string) (*iri.Volume, error) {
+func (s *Server) getIriVolume(ctx context.Context, imageId string) (*iri.Volume, error) {
 	cephImage, err := s.imageStore.Get(ctx, imageId)
 	if err != nil {
 		if errors.Is(err, utils.ErrVolumeNotFound) {
@@ -50,7 +49,7 @@ func (s *Server) filterVolumes(volumes []*iri.Volume, filter *iri.VolumeFilter) 
 	return res
 }
 
-func (s *Server) listVolumes(ctx context.Context, log logr.Logger) ([]*iri.Volume, error) {
+func (s *Server) listVolumes(ctx context.Context) ([]*iri.Volume, error) {
 	cephImages, err := s.imageStore.List(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error listing volumes: %w", err)
@@ -77,7 +76,7 @@ func (s *Server) ListVolumes(ctx context.Context, req *iri.ListVolumesRequest) (
 	log.V(2).Info("Listing volumes")
 
 	if filter := req.Filter; filter != nil && filter.Id != "" {
-		volume, err := s.getIriVolume(ctx, log, filter.Id)
+		volume, err := s.getIriVolume(ctx, filter.Id)
 		if err != nil {
 			if !errors.Is(err, utils.ErrVolumeNotFound) && !errors.Is(err, utils.ErrVolumeIsntManaged) {
 				return nil, utils.ConvertInternalErrorToGRPC(err)
@@ -92,7 +91,7 @@ func (s *Server) ListVolumes(ctx context.Context, req *iri.ListVolumesRequest) (
 		}, nil
 	}
 
-	volumes, err := s.listVolumes(ctx, log)
+	volumes, err := s.listVolumes(ctx)
 	if err != nil {
 		return nil, utils.ConvertInternalErrorToGRPC(err)
 	}

--- a/internal/volumeserver/volumesnapshot_list.go
+++ b/internal/volumeserver/volumesnapshot_list.go
@@ -48,7 +48,7 @@ func (s *Server) filterSnapshot(snapshots []*iri.VolumeSnapshot, filter *iri.Vol
 	return res
 }
 
-func (s *Server) listSnapshots(ctx context.Context, log logr.Logger) ([]*iri.VolumeSnapshot, error) {
+func (s *Server) listSnapshots(ctx context.Context) ([]*iri.VolumeSnapshot, error) {
 	cephSnapshots, err := s.snapshotStore.List(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error listing snapshots: %w", err)
@@ -90,7 +90,7 @@ func (s *Server) ListVolumeSnapshots(ctx context.Context, req *iri.ListVolumeSna
 		}, nil
 	}
 
-	snapshots, err := s.listSnapshots(ctx, log)
+	snapshots, err := s.listSnapshots(ctx)
 	if err != nil {
 		return nil, utils.ConvertInternalErrorToGRPC(err)
 	}

--- a/internal/volumeserver/volumesnapshot_list.go
+++ b/internal/volumeserver/volumesnapshot_list.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (s *Server) getIriVolumeSnapshot(ctx context.Context, log logr.Logger, snapshotId string) (*iri.VolumeSnapshot, error) {
-	log.V(2).Info("Get volume snapshot %s", snapshotId)
+	log.V(2).Info("Get volume snapshot", "snapshotId", snapshotId)
 	cephSnapshot, err := s.snapshotStore.Get(ctx, snapshotId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get snapshot %s: %w", snapshotId, err)

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -18,6 +18,7 @@ import (
 	eventrecorder "github.com/ironcore-dev/provider-utils/eventutils/recorder"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -57,7 +58,7 @@ func TestIntegration_GRPCServer(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.Level(zapcore.Level(-2)), zap.UseDevMode(true)))
 
 	keyEncryptionKeyFile, err := os.CreateTemp(GinkgoT().TempDir(), "keyencryption")
 	Expect(err).NotTo(HaveOccurred())

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -57,8 +57,10 @@ func TestIntegration_GRPCServer(t *testing.T) {
 	RunSpecs(t, "GRPC Server Suite", Label("integration"))
 }
 
+const verboseTestLogLevel = zapcore.Level(-2)
+
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.Level(zapcore.Level(-2)), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.Level(verboseTestLogLevel), zap.UseDevMode(true)))
 
 	keyEncryptionKeyFile, err := os.CreateTemp(GinkgoT().TempDir(), "keyencryption")
 	Expect(err).NotTo(HaveOccurred())

--- a/tests/integration/volume_create_integration_test.go
+++ b/tests/integration/volume_create_integration_test.go
@@ -74,8 +74,7 @@ var _ = Describe("Create Volume", func() {
 				HaveKeyWithValue(api.IOPSLimit, int64(15000)),
 			)),
 			HaveField("Spec.SnapshotRef", BeNil()),
-			HaveField("Spec.Encryption.Type", api.EncryptionTypeUnencrypted),
-			HaveField("Spec.Encryption.EncryptedPassphrase", BeEmpty()),
+			HaveField("Spec.Encryption", BeNil()),
 			HaveField("Status.State", Equal(api.ImageStateAvailable)),
 			HaveField("Status.Access", SatisfyAll(
 				HaveField("Monitors", cephMonitors),

--- a/tests/integration/volume_expand_integration_test.go
+++ b/tests/integration/volume_expand_integration_test.go
@@ -73,9 +73,7 @@ var _ = Describe("Expand Volume", func() {
 				HaveKeyWithValue(api.IOPSLimit, int64(15000)),
 			)),
 			HaveField("Spec.SnapshotRef", BeNil()),
-			HaveField("Spec.Encryption", SatisfyAll(
-				HaveField("Type", api.EncryptionTypeUnencrypted),
-			)),
+			HaveField("Spec.Encryption", BeNil()),
 			HaveField("Status.State", Equal(api.ImageStateAvailable)),
 			HaveField("Status.Access", SatisfyAll(
 				HaveField("Monitors", cephMonitors),
@@ -145,9 +143,7 @@ var _ = Describe("Expand Volume", func() {
 				HaveKeyWithValue(api.IOPSLimit, int64(15000)),
 			)),
 			HaveField("Spec.SnapshotRef", BeNil()),
-			HaveField("Spec.Encryption", SatisfyAll(
-				HaveField("Type", api.EncryptionTypeUnencrypted),
-			)),
+			HaveField("Spec.Encryption", BeNil()),
 			HaveField("Status.State", Equal(api.ImageStateAvailable)),
 			HaveField("Status.Access", SatisfyAll(
 				HaveField("Monitors", cephMonitors),

--- a/tests/integration/volume_list_integration_test.go
+++ b/tests/integration/volume_list_integration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 var _ = Describe("List Volume", func() {
-	It("should create a volume", func(ctx SpecContext) {
+	It("should list volumes", func(ctx SpecContext) {
 		By("creating a volume")
 		createResp, err := volumeClient.CreateVolume(ctx, &iriv1alpha1.CreateVolumeRequest{
 			Volume: &iriv1alpha1.Volume{


### PR DESCRIPTION
# Proposed Changes

- Flatten cloned images of snapshot during snapshot deletion
- Clone snapshots into images and flatten snapshot children if it has before source volume deletion
- Delete volume os-image only if it is not referenced by any other volumes
- Improve error handling in `CreateVolume()`
- Introduce helper functions - `openImage()`, `closeImage()`, `flattenImage()`, `createSnapshot()`, `removeSnapshot()`, `flattenChildImages(), isSnapshotExist()` and use it wherever it can be.

Fixes #809 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deletion flows now clone snapshot sources, flatten child images, and handle finalizers to avoid orphaned data and improve error handling.

* **New Features**
  * Snapshot-based cloning creates managed images that preserve metadata and labels; cloning steps are more traceable via enhanced logs.

* **Improvements**
  * Volume/image creation derives size and optional encryption from snapshot or image sources with safer nil-handling and clearer logging.

* **Chores**
  * Image encryption spec in the public API is now nullable (optional).

* **Tests**
  * Integration tests updated to expect nil encryption for unencrypted volumes and enable more verbose test logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->