### PR TITLE
Reintroduce snapshot state 'Populated'

### DIFF
--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -18,9 +18,10 @@ type Snapshot struct {
 type SnapshotState string
 
 const (
-	SnapshotStatePending SnapshotState = "Pending"
-	SnapshotStateReady   SnapshotState = "Ready"
-	SnapshotStateFailed  SnapshotState = "Failed"
+	SnapshotStatePending   SnapshotState = "Pending"
+	SnapshotStatePopulated SnapshotState = "Populated"
+	SnapshotStateReady     SnapshotState = "Ready"
+	SnapshotStateFailed    SnapshotState = "Failed"
 )
 
 type SnapshotStatus struct {

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -746,7 +746,7 @@ func (r *ImageReconciler) createImageFromSnapshot(ctx context.Context, log logr.
 		return false, nil
 	}
 
-	if snapshot.Status.State != providerapi.SnapshotStateReady {
+	if snapshot.Status.State != providerapi.SnapshotStateReady && snapshot.Status.State != providerapi.SnapshotStatePopulated {
 		log.V(1).Info("snapshot is not populated", "state", snapshot.Status.State)
 		return false, nil
 	}

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -249,8 +249,20 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 		return nil
 	}
 
-	if snapshot.Status.State == providerapi.SnapshotStateReady {
+	// SnapshotStatePopulated is no longer actively used. It has been replaced by SnapshotStateReady.
+	// This block will transition any snapshots that are in SnapshotStatePopulated to SnapshotStateReady.
+	if snapshot.Status.State == providerapi.SnapshotStatePopulated {
 		log.V(1).Info("Snapshot already populated")
+		snapshot.Status.State = providerapi.SnapshotStateReady
+		if _, err = r.store.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to update snapshot: %w", err)
+		}
+
+		return nil
+	}
+
+	if snapshot.Status.State == providerapi.SnapshotStateReady {
+		log.V(1).Info("Snapshot is ready")
 		return nil
 	}
 


### PR DESCRIPTION
# Proposed Changes

The snapshot state 'Populated' was replaced with 'Ready' in commit
`1f839f4`. However, logic to handle old snapshots still in state
'Populated' was left out.

This commit adds the state 'Populated' back and adds logic to transfer
snapshots in state 'Populated' to 'Ready'.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new snapshot state option for expanded state management capabilities.

* **Bug Fixes**
  * Enhanced snapshot readiness validation for improved image creation compatibility.
  * Improved snapshot state transitions and normalization for consistent state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->