### PR TITLE
Implement async worker queues for populate & flatten operations

### DIFF
--- a/api/image.go
+++ b/api/image.go
@@ -19,6 +19,8 @@ type ImageState string
 const (
 	ImageStatePending   ImageState = "Pending"
 	ImageStateAvailable ImageState = "Available"
+	// ImageStateFlatteningChildren indicates deletion is waiting for child images to be flattened.
+	ImageStateFlatteningChildren ImageState = "FlatteningChildren"
 )
 
 type EncryptionState string

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -18,10 +18,13 @@ type Snapshot struct {
 type SnapshotState string
 
 const (
-	SnapshotStatePending   SnapshotState = "Pending"
-	SnapshotStatePopulated SnapshotState = "Populated"
-	SnapshotStateReady     SnapshotState = "Ready"
-	SnapshotStateFailed    SnapshotState = "Failed"
+	SnapshotStatePending    SnapshotState = "Pending"
+	SnapshotStatePopulated  SnapshotState = "Populated"
+	SnapshotStatePopulating SnapshotState = "Populating"
+	SnapshotStateFlattening SnapshotState = "Flattening"
+	SnapshotStateFlattened  SnapshotState = "Flattened"
+	SnapshotStateReady      SnapshotState = "Ready"
+	SnapshotStateFailed     SnapshotState = "Failed"
 )
 
 type SnapshotStatus struct {

--- a/cmd/volumeprovider/app/app.go
+++ b/cmd/volumeprovider/app/app.go
@@ -59,7 +59,18 @@ type CephOptions struct {
 
 	VolumeEventStoreOptions eventrecorder.EventStoreOptions
 
+	// WorkerSize controls the number of concurrent workers for the fast reconcilers
+	// (ImageReconciler, SnapshotReconciler).
 	WorkerSize int
+
+	// SnapshotPopulateLongOpsWorkerSize is the number of concurrent workers used for snapshot populate long-running operations.
+	SnapshotPopulateLongOpsWorkerSize int
+
+	// SnapshotFlattenLongOpsWorkerSize is the number of concurrent workers used for snapshot flatten long-running operations.
+	SnapshotFlattenLongOpsWorkerSize int
+
+	// ImageFlattenLongOpsWorkerSize is the number of concurrent workers used for image flatten long-running operations (deletion-time flattening of children).
+	ImageFlattenLongOpsWorkerSize int
 }
 
 func (o *Options) Defaults() {
@@ -68,6 +79,9 @@ func (o *Options) Defaults() {
 	o.Ceph.BurstDurationInSeconds = 15
 	o.Ceph.PopulatorBufferSize = 5 * 1024 * 1024
 	o.Ceph.WorkerSize = 15
+	o.Ceph.SnapshotPopulateLongOpsWorkerSize = 3
+	o.Ceph.SnapshotFlattenLongOpsWorkerSize = 5
+	o.Ceph.ImageFlattenLongOpsWorkerSize = 5
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
@@ -92,7 +106,12 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.Ceph.VolumeEventStoreOptions.TTL, "volume-event-ttl", 5*time.Minute, "Time to live for volume events.")
 	fs.DurationVar(&o.Ceph.VolumeEventStoreOptions.ResyncInterval, "volume-event-resync-interval", 1*time.Minute, "Interval for resynchronizing the volume events.")
 
-	fs.IntVar(&o.Ceph.WorkerSize, "worker-size", o.Ceph.WorkerSize, "Defines the factor to calculate the burst limits.")
+	fs.IntVar(&o.Ceph.WorkerSize, "worker-size", o.Ceph.WorkerSize, "Number of concurrent workers for the fast image and snapshot reconcilers.")
+
+	fs.IntVar(&o.Ceph.SnapshotPopulateLongOpsWorkerSize, "snapshot-populate-long-ops-worker-size", o.Ceph.SnapshotPopulateLongOpsWorkerSize, "Number of concurrent workers for snapshot populate long-running operations.")
+	fs.IntVar(&o.Ceph.SnapshotFlattenLongOpsWorkerSize, "snapshot-flatten-long-ops-worker-size", o.Ceph.SnapshotFlattenLongOpsWorkerSize, "Number of concurrent workers for snapshot flatten long-running operations.")
+
+	fs.IntVar(&o.Ceph.ImageFlattenLongOpsWorkerSize, "image-flatten-long-ops-worker-size", o.Ceph.ImageFlattenLongOpsWorkerSize, "Number of concurrent workers for image flatten long-running operations (deletion-time flattening of children).")
 }
 
 func (o *Options) MarkFlagsRequired(cmd *cobra.Command) {
@@ -171,6 +190,21 @@ func Run(ctx context.Context, opts Options) error {
 	if opts.Ceph.WorkerSize <= 1 {
 		err := fmt.Errorf("invalid configuration: worker-size must be greater than 1, but got %d", opts.Ceph.WorkerSize)
 		setupLog.Error(err, "Worker size validation failed")
+		return err
+	}
+	if opts.Ceph.SnapshotPopulateLongOpsWorkerSize <= 0 {
+		err := fmt.Errorf("invalid configuration: snapshot-populate-long-ops-worker-size must be greater than 0, but got %d", opts.Ceph.SnapshotPopulateLongOpsWorkerSize)
+		setupLog.Error(err, "Snapshot populate long-ops worker size validation failed")
+		return err
+	}
+	if opts.Ceph.SnapshotFlattenLongOpsWorkerSize <= 0 {
+		err := fmt.Errorf("invalid configuration: snapshot-flatten-long-ops-worker-size must be greater than 0, but got %d", opts.Ceph.SnapshotFlattenLongOpsWorkerSize)
+		setupLog.Error(err, "Snapshot flatten long-ops worker size validation failed")
+		return err
+	}
+	if opts.Ceph.ImageFlattenLongOpsWorkerSize <= 0 {
+		err := fmt.Errorf("invalid configuration: image-flatten-long-ops-worker-size must be greater than 0, but got %d", opts.Ceph.ImageFlattenLongOpsWorkerSize)
+		setupLog.Error(err, "Image flatten long-ops worker size validation failed")
 		return err
 	}
 
@@ -256,10 +290,11 @@ func Run(ctx context.Context, opts Options) error {
 		snapshotEvents,
 		encryptor,
 		controllers.ImageReconcilerOptions{
-			Monitors:   opts.Ceph.Monitors,
-			Client:     opts.Ceph.Client,
-			Pool:       opts.Ceph.Pool,
-			WorkerSize: opts.Ceph.WorkerSize,
+			Monitors:          opts.Ceph.Monitors,
+			Client:            opts.Ceph.Client,
+			Pool:              opts.Ceph.Pool,
+			WorkerSize:        opts.Ceph.WorkerSize,
+			FlattenWorkerSize: opts.Ceph.ImageFlattenLongOpsWorkerSize,
 		},
 	)
 	if err != nil {
@@ -287,6 +322,8 @@ func Run(ctx context.Context, opts Options) error {
 			Pool:                opts.Ceph.Pool,
 			PopulatorBufferSize: opts.Ceph.PopulatorBufferSize,
 			WorkerSize:          opts.Ceph.WorkerSize,
+			PopulateWorkerSize:  opts.Ceph.SnapshotPopulateLongOpsWorkerSize,
+			FlattenWorkerSize:   opts.Ceph.SnapshotFlattenLongOpsWorkerSize,
 		},
 	)
 	if err != nil {

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -145,21 +145,6 @@ func removeSnapshot(snapshot *librbd.Snapshot) error {
 	return nil
 }
 
-func flattenChildImages(log logr.Logger, conn *rados.Conn, img *librbd.Image) error {
-	pools, childImgs, err := img.ListChildren()
-	if err != nil {
-		return fmt.Errorf("unable to list children: %w", err)
-	}
-	log.V(2).Info("Snapshot references", "pools", len(pools), "rbd-images", len(childImgs))
-
-	for i, snapChildImgName := range childImgs {
-		if err := flattenImage(log, conn, pools[i], snapChildImgName); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func snapshotExistsAndProtected(log logr.Logger, ioCtx *rados.IOContext, imageName string, snapshotName string) (bool, bool, error) {
 	img, err := openImage(ioCtx, imageName)
 	if err != nil {

--- a/internal/controllers/image_async.go
+++ b/internal/controllers/image_async.go
@@ -21,9 +21,12 @@ func (r *ImageReconciler) processNextFlattenWorkItem(ctx context.Context, log lo
 	}
 	defer r.flattenQueue.Done(imageID)
 
+	log = log.WithValues("imageId", imageID)
+	ctx = logr.NewContext(ctx, log)
+
 	err := r.processFlattenOperation(ctx, imageID)
 	if err != nil {
-		log.Error(err, "flatten operation failed", "imageId", imageID)
+		log.Error(err, "flatten operation failed")
 		r.flattenQueue.AddRateLimited(imageID)
 		return true
 	}
@@ -36,7 +39,7 @@ func (r *ImageReconciler) processNextFlattenWorkItem(ctx context.Context, log lo
 // until no children remain. When flattening completes, it re-triggers image reconciliation
 // so deletion can proceed (snapshot removal, reparenting, RemoveImage, finalizer removal).
 func (r *ImageReconciler) processFlattenOperation(ctx context.Context, imageID string) error {
-	log := logr.FromContextOrDiscard(ctx).WithValues("imageId", imageID)
+	log := logr.FromContextOrDiscard(ctx)
 
 	image, err := r.images.Get(ctx, imageID)
 	if err != nil {
@@ -79,10 +82,6 @@ func (r *ImageReconciler) processFlattenOperation(ctx context.Context, imageID s
 	if len(childImgs) == 0 {
 		// Flattening complete; let the normal delete flow proceed.
 		log.V(2).Info("No children remain; resuming image deletion")
-		image.Status.State = providerapi.ImageStateAvailable
-		if _, err := r.images.Update(ctx, image); store.IgnoreErrNotFound(err) != nil {
-			return fmt.Errorf("failed to update image state after flattening: %w", err)
-		}
 		r.queue.Add(imageID)
 		return nil
 	}

--- a/internal/controllers/image_async.go
+++ b/internal/controllers/image_async.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/go-logr/logr"
+	providerapi "github.com/ironcore-dev/ceph-provider/api"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
+)
+
+func (r *ImageReconciler) processNextFlattenWorkItem(ctx context.Context, log logr.Logger) bool {
+	imageID, shutdown := r.flattenQueue.Get()
+	if shutdown {
+		return false
+	}
+	defer r.flattenQueue.Done(imageID)
+
+	err := r.processFlattenOperation(ctx, imageID)
+	if err != nil {
+		log.Error(err, "flatten operation failed", "imageId", imageID)
+		r.flattenQueue.AddRateLimited(imageID)
+		return true
+	}
+
+	r.flattenQueue.Forget(imageID)
+	return true
+}
+
+// processFlattenOperation flattens at most one child referencing the image and re-enqueues
+// until no children remain. When flattening completes, it re-triggers image reconciliation
+// so deletion can proceed (snapshot removal, reparenting, RemoveImage, finalizer removal).
+func (r *ImageReconciler) processFlattenOperation(ctx context.Context, imageID string) error {
+	log := logr.FromContextOrDiscard(ctx).WithValues("imageId", imageID)
+
+	image, err := r.images.Get(ctx, imageID)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("failed to get image: %w", err)
+		}
+		return nil
+	}
+	// Only do async flattening during deletion while finalizer is present.
+	if image.DeletedAt == nil {
+		return nil
+	}
+	// Only flatten when deletion is in the flattening-children phase.
+	if image.Status.State != providerapi.ImageStateFlatteningChildren {
+		return nil
+	}
+
+	ioCtx, err := r.conn.OpenIOContext(r.pool)
+	if err != nil {
+		return fmt.Errorf("failed to open IO context: %w", err)
+	}
+	defer ioCtx.Destroy()
+
+	img, err := openImage(ioCtx, ImageIDToRBDID(image.ID))
+	if err != nil {
+		if errors.Is(err, librbd.ErrNotFound) {
+			// Parent image already gone; re-trigger reconcile to let finalizers clear.
+			r.queue.Add(imageID)
+			return nil
+		}
+		return fmt.Errorf("failed to open image: %w", err)
+	}
+	defer closeImage(log, img)
+
+	pools, childImgs, err := img.ListChildren()
+	if err != nil {
+		return fmt.Errorf("failed to list children: %w", err)
+	}
+
+	if len(childImgs) == 0 {
+		// Flattening complete; let the normal delete flow proceed.
+		log.V(2).Info("No children remain; resuming image deletion")
+		image.Status.State = providerapi.ImageStateAvailable
+		if _, err := r.images.Update(ctx, image); store.IgnoreErrNotFound(err) != nil {
+			return fmt.Errorf("failed to update image state after flattening: %w", err)
+		}
+		r.queue.Add(imageID)
+		return nil
+	}
+
+	// Flatten one child per run for fairness and bounded work per item.
+	log.V(2).Info("Flattening child image", "child", childImgs[0], "remaining", len(childImgs)-1)
+	if err := flattenImage(log, r.conn, pools[0], childImgs[0]); err != nil {
+		return fmt.Errorf("failed to flatten child %s: %w", childImgs[0], err)
+	}
+
+	// Re-enqueue to continue flattening the remaining children.
+	r.flattenQueue.Add(imageID)
+	return nil
+}

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -37,10 +37,11 @@ const (
 )
 
 type ImageReconcilerOptions struct {
-	Monitors   string
-	Client     string
-	Pool       string
-	WorkerSize int
+	Monitors          string
+	Client            string
+	Pool              string
+	WorkerSize        int
+	FlattenWorkerSize int
 }
 
 func NewImageReconciler(
@@ -94,10 +95,15 @@ func NewImageReconciler(
 		opts.WorkerSize = 15
 	}
 
+	if opts.FlattenWorkerSize == 0 {
+		opts.FlattenWorkerSize = 5
+	}
+
 	return &ImageReconciler{
 		log:            log,
 		conn:           conn,
 		queue:          workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]()),
+		flattenQueue:   workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]()),
 		images:         images,
 		snapshots:      snapshots,
 		EventRecorder:  eventRecorder,
@@ -108,6 +114,7 @@ func NewImageReconciler(
 		pool:           opts.Pool,
 		keyEncryption:  keyEncryption,
 		workerSize:     opts.WorkerSize,
+		flattenWorkers: opts.FlattenWorkerSize,
 	}, nil
 }
 
@@ -116,6 +123,9 @@ type ImageReconciler struct {
 	conn *rados.Conn
 
 	queue workqueue.TypedRateLimitingInterface[string]
+
+	// Async operation queue (image deletion flattening)
+	flattenQueue workqueue.TypedRateLimitingInterface[string]
 
 	images    store.Store[*providerapi.Image]
 	snapshots store.Store[*providerapi.Snapshot]
@@ -131,6 +141,8 @@ type ImageReconciler struct {
 	keyEncryption encryption.Encryptor
 
 	workerSize int
+
+	flattenWorkers int
 }
 
 func (r *ImageReconciler) Start(ctx context.Context) error {
@@ -174,6 +186,7 @@ func (r *ImageReconciler) Start(ctx context.Context) error {
 	go func() {
 		<-ctx.Done()
 		r.queue.ShutDown()
+		r.flattenQueue.ShutDown()
 	}()
 
 	var wg sync.WaitGroup
@@ -182,6 +195,16 @@ func (r *ImageReconciler) Start(ctx context.Context) error {
 		go func() {
 			defer wg.Done()
 			for r.processNextWorkItem(ctx, log) {
+			}
+		}()
+	}
+
+	// Start async flatten workers (for image deletion)
+	for i := 0; i < r.flattenWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for r.processNextFlattenWorkItem(ctx, log) {
 			}
 		}()
 	}
@@ -214,6 +237,8 @@ const (
 	ImageFinalizer = "image"
 )
 
+var errImageFlattenInProgress = errors.New("image flatten in progress")
+
 func (r *ImageReconciler) deleteImage(ctx context.Context, log logr.Logger, ioCtx *rados.IOContext, image *providerapi.Image) error {
 	if !slices.Contains(image.Finalizers, ImageFinalizer) {
 		log.V(1).Info("image has no finalizer: done")
@@ -221,6 +246,11 @@ func (r *ImageReconciler) deleteImage(ctx context.Context, log logr.Logger, ioCt
 	}
 
 	if err := r.deleteImageSnapshots(ctx, log, ioCtx, image); err != nil {
+		if errors.Is(err, errImageFlattenInProgress) {
+			// Async flatten is running. Keep finalizer; reconciliation will be triggered again
+			// by the flatten worker once flattening is complete.
+			return nil
+		}
 		return fmt.Errorf("failed to delete image snapshots: %w", err)
 	}
 
@@ -288,9 +318,21 @@ func (r *ImageReconciler) deleteImageSnapshots(ctx context.Context, log logr.Log
 		}
 	}
 
-	// flatten all child images of the original image's snapshots
-	if err := flattenChildImages(log, r.conn, img); err != nil {
-		return fmt.Errorf("failed to flatten snapshot child images: %w", err)
+	// If there are still children referencing this image/snapshots, flattening can take a long time.
+	// Move flattening out of the main reconcile worker by delegating to the async flatten queue.
+	_, childImgs, err := img.ListChildren()
+	if err != nil {
+		return fmt.Errorf("unable to list children: %w", err)
+	}
+	if len(childImgs) != 0 {
+		log.V(2).Info("Enqueue image for async flattening", "childCount", len(childImgs))
+		// Persist state so clients/IRI reflect that deletion is waiting for child flattening.
+		image.Status.State = providerapi.ImageStateFlatteningChildren
+		if _, err := r.images.Update(ctx, image); store.IgnoreErrNotFound(err) != nil {
+			return fmt.Errorf("failed to update image flattening state: %w", err)
+		}
+		r.flattenQueue.Add(image.ID)
+		return errImageFlattenInProgress
 	}
 
 	// remove snapshot and update snapshot source in store

--- a/internal/controllers/snapshot_async.go
+++ b/internal/controllers/snapshot_async.go
@@ -25,9 +25,12 @@ func (r *SnapshotReconciler) processNextFlattenWorkItem(ctx context.Context, log
 	}
 	defer r.flattenQueue.Done(snapshotID)
 
+	log = log.WithValues("snapshotId", snapshotID)
+	ctx = logr.NewContext(ctx, log)
+
 	err := r.processFlattenOperation(ctx, snapshotID)
 	if err != nil {
-		log.Error(err, "flatten operation failed", "snapshotId", snapshotID)
+		log.Error(err, "flatten operation failed")
 		r.flattenQueue.AddRateLimited(snapshotID)
 		return true
 	}
@@ -38,7 +41,7 @@ func (r *SnapshotReconciler) processNextFlattenWorkItem(ctx context.Context, log
 
 // processFlattenOperation processes one flatten operation
 func (r *SnapshotReconciler) processFlattenOperation(ctx context.Context, snapshotID string) error {
-	log := logr.FromContextOrDiscard(ctx).WithValues("snapshotId", snapshotID)
+	log := logr.FromContextOrDiscard(ctx)
 
 	snapshot, err := r.store.Get(ctx, snapshotID)
 	if err != nil {
@@ -106,13 +109,16 @@ func (r *SnapshotReconciler) processNextPopulateWorkItem(ctx context.Context, lo
 	}
 	defer r.populateQueue.Done(snapshotID)
 
+	log = log.WithValues("snapshotId", snapshotID)
+	ctx = logr.NewContext(ctx, log)
+
 	err := r.processPopulateOperation(ctx, snapshotID)
 	if err != nil {
-		log.Error(err, "populate operation failed", "snapshotId", snapshotID)
+		log.Error(err, "populate operation failed")
 		if r.populateQueue.NumRequeues(snapshotID) >= maxPopulateRetries {
 			log.Error(err, "populate operation reached max retries; marking snapshot as Failed", "snapshotId", snapshotID, "maxRetries", maxPopulateRetries)
 			snapshot, getErr := r.store.Get(ctx, snapshotID)
-			if getErr == nil {
+			if getErr == nil && snapshot.DeletedAt == nil && snapshot.Status.State == providerapi.SnapshotStatePopulating {
 				snapshot.Status.State = providerapi.SnapshotStateFailed
 				if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
 					log.Error(updateErr, "failed to persist snapshot Failed state after max retries", "snapshotId", snapshotID)
@@ -133,9 +139,25 @@ func (r *SnapshotReconciler) processNextPopulateWorkItem(ctx context.Context, lo
 	return true
 }
 
+// syncSnapshotFromStore reloads the snapshot from the store between slow populate steps.
+// Populate stops when it is missing from the store, is being deleted, is not in Populating state, or has no IronCore image source.
+func (r *SnapshotReconciler) syncSnapshotFromStore(ctx context.Context, snapshotID string) (snap *providerapi.Snapshot, stillPopulating bool, err error) {
+	s, err := r.store.Get(ctx, snapshotID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("failed to get snapshot: %w", err)
+	}
+	if s.DeletedAt != nil || s.Status.State != providerapi.SnapshotStatePopulating || s.Source.IronCoreImage == "" {
+		return nil, false, nil
+	}
+	return s, true, nil
+}
+
 // processPopulateOperation processes one populate operation
 func (r *SnapshotReconciler) processPopulateOperation(ctx context.Context, snapshotID string) error {
-	log := logr.FromContextOrDiscard(ctx).WithValues("snapshotId", snapshotID)
+	log := logr.FromContextOrDiscard(ctx)
 
 	snapshot, err := r.store.Get(ctx, snapshotID)
 	if err != nil {
@@ -159,6 +181,13 @@ func (r *SnapshotReconciler) processPopulateOperation(ctx context.Context, snaps
 	}
 	defer ioCtx.Destroy()
 
+	var platform *ocispec.Platform
+	if snapshot.Labels != nil {
+		if arch, found := snapshot.Labels[providerapi.MachineArchitectureLabel]; found {
+			platform = toPlatform(&arch)
+		}
+	}
+
 	// If the Ceph snapshot already exists, population completed previously (e.g. controller restart
 	// or status update failure). Skip re-populating and just try to advance status to Ready.
 	imageName := SnapshotIDToRBDID(snapshot.ID)
@@ -167,6 +196,33 @@ func (r *SnapshotReconciler) processPopulateOperation(ctx context.Context, snaps
 		return fmt.Errorf("failed to check snapshot existence: %w", err)
 	}
 	if exists {
+		rbdImg, err := openImage(ioCtx, imageName)
+		if err != nil {
+			return fmt.Errorf("failed to open rbd image for snapshot metadata: %w", err)
+		}
+		defer closeImage(log, rbdImg)
+		size, err := rbdImg.GetSize()
+		if err != nil {
+			return fmt.Errorf("failed to get rbd image size: %w", err)
+		}
+		var digest string
+		if snapshot.Status.Digest == "" {
+			digest, _, _, err = resolveIroncoreImageReference(ctx, snapshot.Source.IronCoreImage, platform)
+			if err != nil {
+				return fmt.Errorf("failed to resolve ironcore image digest: %w", err)
+			}
+		}
+		snapshot, stillPopulating, err := r.syncSnapshotFromStore(ctx, snapshot.ID)
+		if err != nil {
+			return err
+		}
+		if !stillPopulating {
+			return nil
+		}
+		snapshot.Status.Size = int64(size)
+		if snapshot.Status.Digest == "" {
+			snapshot.Status.Digest = digest
+		}
 		snapshot.Status.State = providerapi.SnapshotStateReady
 		if _, err := r.store.Update(ctx, snapshot); err != nil {
 			return fmt.Errorf("failed to update snapshot state to Ready: %w", err)
@@ -174,23 +230,19 @@ func (r *SnapshotReconciler) processPopulateOperation(ctx context.Context, snaps
 		return nil
 	}
 
-	var platform *ocispec.Platform
-	if snapshot.Labels != nil {
-		if arch, found := snapshot.Labels[providerapi.MachineArchitectureLabel]; found {
-			platform = toPlatform(&arch)
-		}
-	}
-
-	rc, snapshotSize, digest, err := r.openIroncoreImageSource(ctx, snapshot.Source.IronCoreImage, platform)
+	rc, rootFSSizeBytes, digest, err := openIroncoreImageSource(ctx, snapshot.Source.IronCoreImage, platform)
 	if err != nil {
-		snapshot.Status.State = providerapi.SnapshotStateFailed
-		if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
-			log.Error(updateErr, "Failed to update snapshot after source resolution failure")
-		}
-		// Terminal error: don't retry.
-		return nil
+		return fmt.Errorf("failed to open ironcore image source: %w", err)
 	}
 	defer rc.Close()
+
+	snapshot, stillPopulating, err := r.syncSnapshotFromStore(ctx, snapshot.ID)
+	if err != nil {
+		return err
+	}
+	if !stillPopulating {
+		return nil
+	}
 
 	// Create the backing RBD image if needed.
 	rbdImg, err := openImage(ioCtx, imageName)
@@ -205,7 +257,7 @@ func (r *SnapshotReconciler) processPopulateOperation(ctx context.Context, snaps
 			return fmt.Errorf("failed to set data pool: %w", err)
 		}
 
-		roundedSize := round.OffBytes(snapshotSize)
+		roundedSize := round.OffBytes(rootFSSizeBytes)
 		if err := librbd.CreateImage(ioCtx, imageName, roundedSize, options); err != nil {
 			return fmt.Errorf("failed to create os rbd image: %w", err)
 		}
@@ -215,11 +267,30 @@ func (r *SnapshotReconciler) processPopulateOperation(ctx context.Context, snaps
 			return fmt.Errorf("failed to persist snapshot metadata after image create: %w", err)
 		}
 	} else {
+		size, err := rbdImg.GetSize()
+		if err != nil {
+			_ = rbdImg.Close()
+			return fmt.Errorf("failed to get existing RBD image size: %w", err)
+		}
+		metadataChanged := false
+		if snapshot.Status.Digest == "" {
+			snapshot.Status.Digest = digest
+			metadataChanged = true
+		}
+		if snapshot.Status.Size == 0 {
+			snapshot.Status.Size = int64(size)
+			metadataChanged = true
+		}
 		_ = rbdImg.Close()
+		if metadataChanged {
+			if _, err := r.store.Update(ctx, snapshot); err != nil {
+				return fmt.Errorf("failed to persist snapshot metadata for existing image: %w", err)
+			}
+		}
 	}
 
 	if err := r.prepareSnapshotContent(log, ioCtx, imageName, rc); err != nil {
-		return fmt.Errorf("populate failed: %w", err)
+		return fmt.Errorf("failed to populate snapshot: %w", err)
 	}
 
 	if err := createSnapshot(log, ioCtx, ImageSnapshotVersion, imageName); err != nil {
@@ -231,6 +302,14 @@ func (r *SnapshotReconciler) processPopulateOperation(ctx context.Context, snaps
 		if !exists {
 			return fmt.Errorf("failed to create ironcore image snapshot after population: %w", err)
 		}
+	}
+
+	snapshot, stillPopulating, err = r.syncSnapshotFromStore(ctx, snapshot.ID)
+	if err != nil {
+		return err
+	}
+	if !stillPopulating {
+		return nil
 	}
 
 	snapshot.Status.State = providerapi.SnapshotStateReady

--- a/internal/controllers/snapshot_async.go
+++ b/internal/controllers/snapshot_async.go
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/go-logr/logr"
+	providerapi "github.com/ironcore-dev/ceph-provider/api"
+	"github.com/ironcore-dev/ceph-provider/internal/round"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const maxPopulateRetries = 10
+
+func (r *SnapshotReconciler) processNextFlattenWorkItem(ctx context.Context, log logr.Logger) bool {
+	snapshotID, shutdown := r.flattenQueue.Get()
+	if shutdown {
+		return false
+	}
+	defer r.flattenQueue.Done(snapshotID)
+
+	err := r.processFlattenOperation(ctx, snapshotID)
+	if err != nil {
+		log.Error(err, "flatten operation failed", "snapshotId", snapshotID)
+		r.flattenQueue.AddRateLimited(snapshotID)
+		return true
+	}
+
+	r.flattenQueue.Forget(snapshotID)
+	return true
+}
+
+// processFlattenOperation processes one flatten operation
+func (r *SnapshotReconciler) processFlattenOperation(ctx context.Context, snapshotID string) error {
+	log := logr.FromContextOrDiscard(ctx).WithValues("snapshotId", snapshotID)
+
+	snapshot, err := r.store.Get(ctx, snapshotID)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("failed to get snapshot: %w", err)
+		}
+		return nil
+	}
+	// Only process snapshots that are actually in "Flattening" (delete path).
+	if snapshot.Status.State != providerapi.SnapshotStateFlattening || snapshot.DeletedAt == nil {
+		return nil
+	}
+
+	ioCtx, err := r.conn.OpenIOContext(r.pool)
+	if err != nil {
+		return fmt.Errorf("failed to open IO context: %w", err)
+	}
+	defer ioCtx.Destroy()
+
+	rbdID, snapshotIDName, err := getSnapshotSourceDetails(snapshot)
+	if err != nil {
+		return fmt.Errorf("failed to get snapshot source details: %w", err)
+	}
+
+	img, err := librbd.OpenImage(ioCtx, rbdID, snapshotIDName)
+	if err != nil {
+		if errors.Is(err, librbd.ErrNotFound) {
+			snapshot.Status.State = providerapi.SnapshotStateFlattened
+			if _, err := r.store.Update(ctx, snapshot); err != nil {
+				return fmt.Errorf("failed to update snapshot state to Flattened: %w", err)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to open image: %w", err)
+	}
+	defer closeImage(log, img)
+
+	pools, childImgs, err := img.ListChildren()
+	if err != nil {
+		return fmt.Errorf("failed to list children: %w", err)
+	}
+
+	if len(childImgs) == 0 {
+		snapshot.Status.State = providerapi.SnapshotStateFlattened
+		if _, err := r.store.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to update snapshot state to Flattened: %w", err)
+		}
+		return nil
+	}
+
+	log.V(2).Info("Flattening child image", "child", childImgs[0], "remaining", len(childImgs)-1)
+	err = flattenImage(log, r.conn, pools[0], childImgs[0])
+	if err != nil {
+		return fmt.Errorf("failed to flatten child %s: %w", childImgs[0], err)
+	}
+
+	r.flattenQueue.Add(snapshotID)
+	return nil
+}
+
+func (r *SnapshotReconciler) processNextPopulateWorkItem(ctx context.Context, log logr.Logger) bool {
+	snapshotID, shutdown := r.populateQueue.Get()
+	if shutdown {
+		return false
+	}
+	defer r.populateQueue.Done(snapshotID)
+
+	err := r.processPopulateOperation(ctx, snapshotID)
+	if err != nil {
+		log.Error(err, "populate operation failed", "snapshotId", snapshotID)
+		if r.populateQueue.NumRequeues(snapshotID) >= maxPopulateRetries {
+			log.Error(err, "populate operation reached max retries; marking snapshot as Failed", "snapshotId", snapshotID, "maxRetries", maxPopulateRetries)
+			snapshot, getErr := r.store.Get(ctx, snapshotID)
+			if getErr == nil {
+				snapshot.Status.State = providerapi.SnapshotStateFailed
+				if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
+					log.Error(updateErr, "failed to persist snapshot Failed state after max retries", "snapshotId", snapshotID)
+				}
+			} else if !errors.Is(getErr, store.ErrNotFound) {
+				log.Error(getErr, "failed to get snapshot to mark Failed after max retries", "snapshotId", snapshotID)
+			}
+
+			r.populateQueue.Forget(snapshotID)
+			return true
+		}
+
+		r.populateQueue.AddRateLimited(snapshotID)
+		return true
+	}
+
+	r.populateQueue.Forget(snapshotID)
+	return true
+}
+
+// processPopulateOperation processes one populate operation
+func (r *SnapshotReconciler) processPopulateOperation(ctx context.Context, snapshotID string) error {
+	log := logr.FromContextOrDiscard(ctx).WithValues("snapshotId", snapshotID)
+
+	snapshot, err := r.store.Get(ctx, snapshotID)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("failed to get snapshot: %w", err)
+		}
+		return nil
+	}
+
+	// Only process snapshots that are actually in "Populating".
+	if snapshot.Status.State != providerapi.SnapshotStatePopulating {
+		return nil
+	}
+	if snapshot.Source.IronCoreImage == "" {
+		return nil
+	}
+
+	ioCtx, err := r.conn.OpenIOContext(r.pool)
+	if err != nil {
+		return fmt.Errorf("failed to open IO context: %w", err)
+	}
+	defer ioCtx.Destroy()
+
+	// If the Ceph snapshot already exists, population completed previously (e.g. controller restart
+	// or status update failure). Skip re-populating and just try to advance status to Ready.
+	imageName := SnapshotIDToRBDID(snapshot.ID)
+	exists, _, err := snapshotExistsAndProtected(log, ioCtx, imageName, ImageSnapshotVersion)
+	if err != nil {
+		return fmt.Errorf("failed to check snapshot existence: %w", err)
+	}
+	if exists {
+		snapshot.Status.State = providerapi.SnapshotStateReady
+		if _, err := r.store.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to update snapshot state to Ready: %w", err)
+		}
+		return nil
+	}
+
+	var platform *ocispec.Platform
+	if snapshot.Labels != nil {
+		if arch, found := snapshot.Labels[providerapi.MachineArchitectureLabel]; found {
+			platform = toPlatform(&arch)
+		}
+	}
+
+	rc, snapshotSize, digest, err := r.openIroncoreImageSource(ctx, snapshot.Source.IronCoreImage, platform)
+	if err != nil {
+		snapshot.Status.State = providerapi.SnapshotStateFailed
+		if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
+			log.Error(updateErr, "Failed to update snapshot after source resolution failure")
+		}
+		// Terminal error: don't retry.
+		return nil
+	}
+	defer rc.Close()
+
+	// Create the backing RBD image if needed.
+	rbdImg, err := openImage(ioCtx, imageName)
+	if err != nil {
+		if !errors.Is(err, librbd.ErrNotFound) {
+			return fmt.Errorf("failed to open RBD image: %w", err)
+		}
+
+		options := librbd.NewRbdImageOptions()
+		defer options.Destroy()
+		if err := options.SetString(librbd.RbdImageOptionDataPool, r.pool); err != nil {
+			return fmt.Errorf("failed to set data pool: %w", err)
+		}
+
+		roundedSize := round.OffBytes(snapshotSize)
+		if err := librbd.CreateImage(ioCtx, imageName, roundedSize, options); err != nil {
+			return fmt.Errorf("failed to create os rbd image: %w", err)
+		}
+		snapshot.Status.Digest = digest
+		snapshot.Status.Size = int64(roundedSize)
+		if _, err := r.store.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to persist snapshot metadata after image create: %w", err)
+		}
+	} else {
+		_ = rbdImg.Close()
+	}
+
+	if err := r.prepareSnapshotContent(log, ioCtx, imageName, rc); err != nil {
+		return fmt.Errorf("populate failed: %w", err)
+	}
+
+	if err := createSnapshot(log, ioCtx, ImageSnapshotVersion, imageName); err != nil {
+		// Treat "already exists" as success to keep this step idempotent across retries/restarts.
+		exists, _, existsErr := snapshotExistsAndProtected(log, ioCtx, imageName, ImageSnapshotVersion)
+		if existsErr != nil {
+			log.Error(existsErr, "Failed to check snapshot existence after createSnapshot error")
+		}
+		if !exists {
+			return fmt.Errorf("failed to create ironcore image snapshot after population: %w", err)
+		}
+	}
+
+	snapshot.Status.State = providerapi.SnapshotStateReady
+	if _, err := r.store.Update(ctx, snapshot); err != nil {
+		return fmt.Errorf("failed to update snapshot: %w", err)
+	}
+	return nil
+}

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-logr/logr"
 	providerapi "github.com/ironcore-dev/ceph-provider/api"
 	"github.com/ironcore-dev/ceph-provider/internal/rater"
-	"github.com/ironcore-dev/ceph-provider/internal/round"
 	"github.com/ironcore-dev/ceph-provider/internal/utils"
 	ironcoreimage "github.com/ironcore-dev/ironcore-image"
 	"github.com/ironcore-dev/provider-utils/eventutils/event"
@@ -30,6 +29,8 @@ type SnapshotReconcilerOptions struct {
 	Pool                string
 	PopulatorBufferSize int64
 	WorkerSize          int
+	FlattenWorkerSize   int
+	PopulateWorkerSize  int
 }
 
 func NewSnapshotReconciler(
@@ -68,6 +69,14 @@ func NewSnapshotReconciler(
 		opts.WorkerSize = 15
 	}
 
+	// Set defaults for async operations
+	if opts.FlattenWorkerSize == 0 {
+		opts.FlattenWorkerSize = 5
+	}
+	if opts.PopulateWorkerSize == 0 {
+		opts.PopulateWorkerSize = 3
+	}
+
 	return &SnapshotReconciler{
 		log:                 log,
 		conn:                conn,
@@ -78,6 +87,10 @@ func NewSnapshotReconciler(
 		pool:                opts.Pool,
 		populatorBufferSize: opts.PopulatorBufferSize,
 		workerSize:          opts.WorkerSize,
+		flattenQueue:        workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]()),
+		populateQueue:       workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]()),
+		flattenWorkers:      opts.FlattenWorkerSize,
+		populateWorkers:     opts.PopulateWorkerSize,
 	}, nil
 }
 
@@ -94,6 +107,14 @@ type SnapshotReconciler struct {
 	populatorBufferSize int64
 
 	workerSize int
+
+	// Async operation queues
+	flattenQueue  workqueue.TypedRateLimitingInterface[string]
+	populateQueue workqueue.TypedRateLimitingInterface[string]
+
+	// Configuration
+	flattenWorkers  int
+	populateWorkers int
 }
 
 func (r *SnapshotReconciler) Start(ctx context.Context) error {
@@ -112,14 +133,37 @@ func (r *SnapshotReconciler) Start(ctx context.Context) error {
 	go func() {
 		<-ctx.Done()
 		r.queue.ShutDown()
+		r.flattenQueue.ShutDown()
+		r.populateQueue.ShutDown()
 	}()
 
 	var wg sync.WaitGroup
+	// Start fast workers (existing)
 	for i := 0; i < r.workerSize; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for r.processNextWorkItem(ctx, log) {
+			}
+		}()
+	}
+
+	// Start flatten workers
+	for i := 0; i < r.flattenWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for r.processNextFlattenWorkItem(ctx, log) {
+			}
+		}()
+	}
+
+	// Start populate workers
+	for i := 0; i < r.populateWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for r.processNextPopulateWorkItem(ctx, log) {
 			}
 		}()
 	}
@@ -168,58 +212,84 @@ func (r *SnapshotReconciler) deleteSnapshot(ctx context.Context, log logr.Logger
 		if !errors.Is(err, librbd.ErrNotFound) {
 			return fmt.Errorf("failed to open rbd image: %w", err)
 		}
-		snapshot.Finalizers = utils.DeleteSliceElement(snapshot.Finalizers, SnapshotFinalizer)
-		if _, err := r.store.Update(ctx, snapshot); store.IgnoreErrNotFound(err) != nil {
-			return fmt.Errorf("failed to update snapshot metadata: %w", err)
+		// Parent image or snapshot is gone; treat flattening as complete and let cleanup handle the rest.
+		snapshot.Status.State = providerapi.SnapshotStateFlattened
+		if _, err := r.store.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to update snapshot state to Flattened: %w", err)
 		}
-		log.V(2).Info("Removed snapshot finalizer")
 		return nil
 	}
-	shouldClose := true
-	defer func() {
-		if shouldClose {
-			closeImage(log, img)
-		}
-	}()
+	defer closeImage(log, img)
 
-	if err := flattenChildImages(log, r.conn, img); err != nil {
-		return fmt.Errorf("failed to flatten snapshot child images: %w", err)
+	_, childImgs, err := img.ListChildren()
+	if err != nil {
+		return fmt.Errorf("unable to list children: %w", err)
 	}
 
-	log.V(2).Info("Remove snapshot")
-	rbdSnapshot := img.GetSnapshot(snapshotID)
-	if err := removeSnapshot(rbdSnapshot); err != nil {
-		return fmt.Errorf("failed to remove snapshot: %w", err)
+	if snapshot.Status.State != providerapi.SnapshotStateFlattening {
+		snapshot.Status.State = providerapi.SnapshotStateFlattening
+		if _, err := r.store.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to update snapshot: %w", err)
+		}
+	}
+
+	// Delegate flattening to the async flatten queue. The worker will set state to Flattened
+	// when flattening completes (or no children remain)
+	if len(childImgs) == 0 {
+		r.flattenQueue.Add(snapshot.ID)
+		return nil
+	}
+
+	r.flattenQueue.Add(snapshot.ID)
+	return nil
+}
+
+func (r *SnapshotReconciler) cleanupFlattenedSnapshot(ctx context.Context, log logr.Logger, ioCtx *rados.IOContext, snapshot *providerapi.Snapshot) error {
+	if !slices.Contains(snapshot.Finalizers, SnapshotFinalizer) {
+		return nil
+	}
+
+	rbdID, snapName, err := getSnapshotSourceDetails(snapshot)
+	if err != nil {
+		return fmt.Errorf("failed to get snapshot source details: %w", err)
+	}
+
+	img, err := openImage(ioCtx, rbdID)
+	if err != nil {
+		if !errors.Is(err, librbd.ErrNotFound) {
+			return fmt.Errorf("failed to open image: %w", err)
+		}
+	} else {
+		defer closeImage(log, img)
+
+		rbdSnapshot := img.GetSnapshot(snapName)
+		if err := removeSnapshot(rbdSnapshot); err != nil && !errors.Is(err, librbd.ErrNotFound) {
+			return fmt.Errorf("failed to remove snapshot: %w", err)
+		}
+	}
+
+	// deletes os-image if not referenced by any volume
+	if snapshot.Source.IronCoreImage != "" {
+		if err := librbd.RemoveImage(ioCtx, rbdID); err != nil && !errors.Is(err, librbd.ErrNotFound) {
+			return fmt.Errorf("failed to remove ironcore os-image: %w", err)
+		}
+	}
+
+	// deletes parent rbd image of snapshot which is created during source volume deletion
+	// and has no any other reference except snapshot.
+	// cloneSnapshot created both the RBD and the store entry; remove RBD before the store to avoid a leaked image.
+	if rbdID == ImageIDToRBDID(snapshot.ID) {
+		if err := librbd.RemoveImage(ioCtx, rbdID); err != nil && !errors.Is(err, librbd.ErrNotFound) {
+			return fmt.Errorf("failed to remove RBD image for snapshot clone: %w", err)
+		}
+		if err := r.images.Delete(ctx, snapshot.ID); store.IgnoreErrNotFound(err) != nil {
+			return fmt.Errorf("failed to remove image store entry: %w", err)
+		}
 	}
 
 	snapshot.Finalizers = utils.DeleteSliceElement(snapshot.Finalizers, SnapshotFinalizer)
 	if _, err := r.store.Update(ctx, snapshot); store.IgnoreErrNotFound(err) != nil {
 		return fmt.Errorf("failed to update snapshot metadata: %w", err)
-	}
-	log.V(2).Info("Removed snapshot finalizer")
-
-	// deletes os-image if not referenced by any volume
-	if snapshot.Source.IronCoreImage != "" {
-		log.V(2).Info("Remove ironcore os-image")
-		shouldClose = false
-		if err := img.Close(); err != nil {
-			return fmt.Errorf("unable to close ironcore os-image: %w", err)
-		}
-
-		if err := librbd.RemoveImage(ioCtx, rbdID); err != nil {
-			return fmt.Errorf("unable to remove ironcore os-image: %w", err)
-		}
-		log.V(2).Info("Ironcore os-image removed")
-	}
-
-	// deletes parent rbd image of snapshot which is created during source volume deletion
-	// and has no any other reference except snapshot
-	if rbdID == ImageIDToRBDID(snapshotID) {
-		log.V(2).Info("Remove parent rbd image")
-		if err := r.images.Delete(ctx, snapshotID); store.IgnoreErrNotFound(err) != nil {
-			return fmt.Errorf("unable to remove parent rbd image: %w", err)
-		}
-		log.V(2).Info("Removed parent rbd image")
 	}
 	return nil
 }
@@ -242,10 +312,15 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 	}
 
 	if snapshot.DeletedAt != nil {
-		if err := r.deleteSnapshot(ctx, log, ioCtx, snapshot); err != nil {
-			return fmt.Errorf("failed to delete snapshot: %w", err)
+		if snapshot.Status.State != providerapi.SnapshotStateFlattened {
+			if err := r.deleteSnapshot(ctx, log, ioCtx, snapshot); err != nil {
+				return fmt.Errorf("failed to delete snapshot: %w", err)
+			}
 		}
-		log.V(1).Info("Successfully deleted snapshot")
+
+		if snapshot.Status.State == providerapi.SnapshotStateFlattened {
+			return r.cleanupFlattenedSnapshot(ctx, log, ioCtx, snapshot)
+		}
 		return nil
 	}
 
@@ -290,93 +365,52 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 		return nil
 	}
 
-	if snapshot.Status.State == providerapi.SnapshotStateFailed {
-		log.V(1).Info("Rbd snapshot does not exist, so snapshot in store is marked as failed")
+	if snapshot.Status.State == providerapi.SnapshotStateFlattening {
+		r.flattenQueue.Add(snapshot.ID)
+		return nil
+	}
+	if snapshot.Status.State == providerapi.SnapshotStatePopulating {
+		r.populateQueue.Add(snapshot.ID)
 		return nil
 	}
 
-	log.V(1).Info("Rbd snapshot does not exist, start reconciliation")
+	if !slices.Contains(snapshot.Finalizers, SnapshotFinalizer) {
+		snapshot.Finalizers = append(snapshot.Finalizers, SnapshotFinalizer)
+		if _, err := r.store.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to set finalizers: %w", err)
+		}
+	}
+
 	switch {
 	case snapshot.Source.IronCoreImage != "":
-		err = r.reconcileIroncoreImageSnapshot(ctx, log, ioCtx, snapshot)
+		// Ironcore-image snapshots are populated asynchronously by the populate workers.
+		snapshot.Status.State = providerapi.SnapshotStatePopulating
+		if _, err := r.store.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to persist populating snapshot state: %w", err)
+		}
+		r.populateQueue.Add(snapshot.ID)
+		return nil
 	case snapshot.Source.VolumeImageID != "":
-		err = r.reconcileVolumeImageSnapshot(ctx, log, ioCtx, snapshot)
+		if err := r.reconcileVolumeImageSnapshot(ctx, log, ioCtx, snapshot); err != nil {
+			snapshot.Status.State = providerapi.SnapshotStateFailed
+			if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
+				return errors.Join(err, fmt.Errorf("failed to update snapshot state: %w", updateErr))
+			}
+			return fmt.Errorf("failed to reconcile snapshot: %w", err)
+		}
+		return nil
 	default:
 		return fmt.Errorf("snapshot source not found")
 	}
-	if err != nil {
-		snapshot.Status.State = providerapi.SnapshotStateFailed
-		if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
-			return errors.Join(err, fmt.Errorf("failed to update snapshot state: %w", updateErr))
-		}
-		return fmt.Errorf("failed to reconcile snapshot: %w", err)
-	}
-
-	snapshot.Status.State = providerapi.SnapshotStateReady
-	if _, err = r.store.Update(ctx, snapshot); err != nil {
-		return fmt.Errorf("failed to update snapshot: %w", err)
-	}
-
-	return nil
-}
-func (r *SnapshotReconciler) reconcileIroncoreImageSnapshot(ctx context.Context, log logr.Logger, ioCtx *rados.IOContext, snapshot *providerapi.Snapshot) error {
-	var platform *ocispec.Platform
-
-	if snapshot.Labels != nil {
-		if arch, found := snapshot.Labels[providerapi.MachineArchitectureLabel]; found {
-			log.V(2).Info("Snapshot architecture", "architecture", arch)
-			platform = toPlatform(&arch)
-		}
-	}
-
-	rc, snapshotSize, digest, err := r.openIroncoreImageSource(ctx, snapshot.Source.IronCoreImage, platform)
-	if err != nil {
-		return fmt.Errorf("failed to open snapshot source: %w", err)
-	}
-	defer func() {
-		if err := rc.Close(); err != nil {
-			log.Error(err, "failed to close snapshot source")
-		}
-	}()
-
-	options := librbd.NewRbdImageOptions()
-	defer options.Destroy()
-
-	//TODO: different pool for OS images?
-	if err := options.SetString(librbd.RbdImageOptionDataPool, r.pool); err != nil {
-		return fmt.Errorf("failed to set data pool: %w", err)
-	}
-	log.V(2).Info("Configured pool", "pool", r.pool)
-
-	rbdImageID := SnapshotIDToRBDID(snapshot.ID)
-	roundedSize := round.OffBytes(snapshotSize)
-
-	if err = librbd.CreateImage(ioCtx, rbdImageID, roundedSize, options); err != nil {
-		return fmt.Errorf("failed to create os rbd image: %w", err)
-	}
-	log.V(2).Info("Created rbd image", "bytes", roundedSize)
-
-	if err := r.prepareSnapshotContent(log, ioCtx, rbdImageID, rc); err != nil {
-		return fmt.Errorf("failed to prepare snapshot content: %w", err)
-	}
-
-	log.V(2).Info("Create ironcore image snapshot", "ImageID", rbdImageID)
-	if err := createSnapshot(log, ioCtx, ImageSnapshotVersion, rbdImageID); err != nil {
-		return fmt.Errorf("failed to create ironcore image snapshot: %w", err)
-	}
-
-	snapshot.Status.Digest = digest
-	snapshot.Status.Size = int64(roundedSize)
-	return nil
 }
 
 func (r *SnapshotReconciler) reconcileVolumeImageSnapshot(ctx context.Context, log logr.Logger, ioCtx *rados.IOContext, snapshot *providerapi.Snapshot) error {
 	img, err := r.images.Get(ctx, snapshot.Source.VolumeImageID)
 	if err != nil {
-		if !errors.Is(err, store.ErrNotFound) {
-			return fmt.Errorf("failed to fetch image from store: %w", err)
+		if errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("source volume image not found: %w", err)
 		}
-		return nil
+		return fmt.Errorf("failed to fetch image from store: %w", err)
 	}
 
 	log.V(2).Info("Create volume image snapshot", "ImageID", img.ID)
@@ -385,6 +419,10 @@ func (r *SnapshotReconciler) reconcileVolumeImageSnapshot(ctx context.Context, l
 	}
 
 	snapshot.Status.Size = int64(img.Status.Size)
+	snapshot.Status.State = providerapi.SnapshotStateReady
+	if _, err := r.store.Update(ctx, snapshot); err != nil {
+		return fmt.Errorf("failed to persist snapshot after creating volume image snapshot: %w", err)
+	}
 	return nil
 }
 

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -196,34 +196,10 @@ const (
 	SnapshotFinalizer = "snapshot"
 )
 
-func (r *SnapshotReconciler) deleteSnapshot(ctx context.Context, log logr.Logger, ioCtx *rados.IOContext, snapshot *providerapi.Snapshot) error {
+func (r *SnapshotReconciler) deleteSnapshot(ctx context.Context, log logr.Logger, snapshot *providerapi.Snapshot) error {
 	if !slices.Contains(snapshot.Finalizers, SnapshotFinalizer) {
 		log.V(1).Info("snapshot has no finalizer: done")
 		return nil
-	}
-
-	rbdID, snapshotID, err := getSnapshotSourceDetails(snapshot)
-	if err != nil {
-		return fmt.Errorf("failed to get snapshot source details: %w", err)
-	}
-
-	img, err := librbd.OpenImage(ioCtx, rbdID, snapshotID)
-	if err != nil {
-		if !errors.Is(err, librbd.ErrNotFound) {
-			return fmt.Errorf("failed to open rbd image: %w", err)
-		}
-		// Parent image or snapshot is gone; treat flattening as complete and let cleanup handle the rest.
-		snapshot.Status.State = providerapi.SnapshotStateFlattened
-		if _, err := r.store.Update(ctx, snapshot); err != nil {
-			return fmt.Errorf("failed to update snapshot state to Flattened: %w", err)
-		}
-		return nil
-	}
-	defer closeImage(log, img)
-
-	_, childImgs, err := img.ListChildren()
-	if err != nil {
-		return fmt.Errorf("unable to list children: %w", err)
 	}
 
 	if snapshot.Status.State != providerapi.SnapshotStateFlattening {
@@ -233,13 +209,7 @@ func (r *SnapshotReconciler) deleteSnapshot(ctx context.Context, log logr.Logger
 		}
 	}
 
-	// Delegate flattening to the async flatten queue. The worker will set state to Flattened
-	// when flattening completes (or no children remain)
-	if len(childImgs) == 0 {
-		r.flattenQueue.Add(snapshot.ID)
-		return nil
-	}
-
+	// Delegate flattening to the async flatten queue. The async flatten worker sets state to Flattened when done.
 	r.flattenQueue.Add(snapshot.ID)
 	return nil
 }
@@ -313,7 +283,7 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 
 	if snapshot.DeletedAt != nil {
 		if snapshot.Status.State != providerapi.SnapshotStateFlattened {
-			if err := r.deleteSnapshot(ctx, log, ioCtx, snapshot); err != nil {
+			if err := r.deleteSnapshot(ctx, log, snapshot); err != nil {
 				return fmt.Errorf("failed to delete snapshot: %w", err)
 			}
 		}
@@ -365,6 +335,11 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 		return nil
 	}
 
+	if snapshot.Status.State == providerapi.SnapshotStateFailed {
+		log.V(1).Info("Snapshot is in failed state")
+		return nil
+	}
+
 	if snapshot.Status.State == providerapi.SnapshotStateFlattening {
 		r.flattenQueue.Add(snapshot.ID)
 		return nil
@@ -372,13 +347,6 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 	if snapshot.Status.State == providerapi.SnapshotStatePopulating {
 		r.populateQueue.Add(snapshot.ID)
 		return nil
-	}
-
-	if !slices.Contains(snapshot.Finalizers, SnapshotFinalizer) {
-		snapshot.Finalizers = append(snapshot.Finalizers, SnapshotFinalizer)
-		if _, err := r.store.Update(ctx, snapshot); err != nil {
-			return fmt.Errorf("failed to set finalizers: %w", err)
-		}
 	}
 
 	switch {
@@ -426,33 +394,46 @@ func (r *SnapshotReconciler) reconcileVolumeImageSnapshot(ctx context.Context, l
 	return nil
 }
 
-func (r *SnapshotReconciler) openIroncoreImageSource(ctx context.Context, imageReference string, platform *ocispec.Platform) (io.ReadCloser, uint64, string, error) {
+// resolveIroncoreImageReference resolves imageReference for populate and returns digest, root filesystem size, and getSourceStream to read layer bytes.
+func resolveIroncoreImageReference(ctx context.Context, imageReference string, platform *ocispec.Platform) (digest string, rootFSSizeBytes uint64, getSourceStream func() (io.ReadCloser, error), err error) {
 	osImgSrc, err := createOsImageSource(platform)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to create os image source: %w", err)
+		return "", 0, nil, fmt.Errorf("failed to create os image source: %w", err)
 	}
 
 	img, err := osImgSrc.Resolve(ctx, imageReference)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to resolve image ref in os image source: %w", err)
+		return "", 0, nil, fmt.Errorf("failed to resolve image ref in os image source: %w", err)
 	}
 
 	ironcoreImage, err := ironcoreimage.ResolveImage(ctx, img)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to resolve ironcore image: %w", err)
+		return "", 0, nil, fmt.Errorf("failed to resolve ironcore image: %w", err)
 	}
 
 	rootFS := ironcoreImage.RootFS
 	if rootFS == nil {
-		return nil, 0, "", fmt.Errorf("image has no root fs")
+		return "", 0, nil, fmt.Errorf("image has no root fs")
 	}
 
-	content, err := rootFS.Content(ctx)
+	digest = img.Descriptor().Digest.String()
+	rootFSSizeBytes = uint64(rootFS.Descriptor().Size)
+	getSourceStream = func() (io.ReadCloser, error) {
+		return rootFS.Content(ctx)
+	}
+	return digest, rootFSSizeBytes, getSourceStream, nil
+}
+
+func openIroncoreImageSource(ctx context.Context, imageReference string, platform *ocispec.Platform) (io.ReadCloser, uint64, string, error) {
+	digest, rootFSSizeBytes, getSourceStream, err := resolveIroncoreImageReference(ctx, imageReference, platform)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to get root fs content: %w", err)
+		return nil, 0, "", err
 	}
-
-	return content, uint64(rootFS.Descriptor().Size), img.Descriptor().Digest.String(), nil
+	rc, err := getSourceStream()
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to get source stream: %w", err)
+	}
+	return rc, rootFSSizeBytes, digest, nil
 }
 
 func (r *SnapshotReconciler) prepareSnapshotContent(log logr.Logger, ioCtx *rados.IOContext, imageName string, rc io.ReadCloser) error {

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -365,6 +365,11 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 		return nil
 	}
 
+	if snapshot.Status.State == providerapi.SnapshotStateFailed {
+		log.V(1).Info("Snapshot is in failed state")
+		return nil
+	}
+
 	if snapshot.Status.State == providerapi.SnapshotStateFlattening {
 		r.flattenQueue.Add(snapshot.ID)
 		return nil
@@ -426,33 +431,46 @@ func (r *SnapshotReconciler) reconcileVolumeImageSnapshot(ctx context.Context, l
 	return nil
 }
 
-func (r *SnapshotReconciler) openIroncoreImageSource(ctx context.Context, imageReference string, platform *ocispec.Platform) (io.ReadCloser, uint64, string, error) {
+// resolveIroncoreImageReference resolves imageReference for populate and returns digest, root filesystem size, and getSourceStream to read layer bytes.
+func resolveIroncoreImageReference(ctx context.Context, imageReference string, platform *ocispec.Platform) (digest string, rootFSSizeBytes uint64, getSourceStream func() (io.ReadCloser, error), err error) {
 	osImgSrc, err := createOsImageSource(platform)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to create os image source: %w", err)
+		return "", 0, nil, fmt.Errorf("failed to create os image source: %w", err)
 	}
 
 	img, err := osImgSrc.Resolve(ctx, imageReference)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to resolve image ref in os image source: %w", err)
+		return "", 0, nil, fmt.Errorf("failed to resolve image ref in os image source: %w", err)
 	}
 
 	ironcoreImage, err := ironcoreimage.ResolveImage(ctx, img)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to resolve ironcore image: %w", err)
+		return "", 0, nil, fmt.Errorf("failed to resolve ironcore image: %w", err)
 	}
 
 	rootFS := ironcoreImage.RootFS
 	if rootFS == nil {
-		return nil, 0, "", fmt.Errorf("image has no root fs")
+		return "", 0, nil, fmt.Errorf("image has no root fs")
 	}
 
-	content, err := rootFS.Content(ctx)
+	digest = img.Descriptor().Digest.String()
+	rootFSSizeBytes = uint64(rootFS.Descriptor().Size)
+	getSourceStream = func() (io.ReadCloser, error) {
+		return rootFS.Content(ctx)
+	}
+	return digest, rootFSSizeBytes, getSourceStream, nil
+}
+
+func openIroncoreImageSource(ctx context.Context, imageReference string, platform *ocispec.Platform) (io.ReadCloser, uint64, string, error) {
+	digest, rootFSSizeBytes, getSourceStream, err := resolveIroncoreImageReference(ctx, imageReference, platform)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to get root fs content: %w", err)
+		return nil, 0, "", err
 	}
-
-	return content, uint64(rootFS.Descriptor().Size), img.Descriptor().Digest.String(), nil
+	rc, err := getSourceStream()
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to get source stream: %w", err)
+	}
+	return rc, rootFSSizeBytes, digest, nil
 }
 
 func (r *SnapshotReconciler) prepareSnapshotContent(log logr.Logger, ioCtx *rados.IOContext, imageName string, rc io.ReadCloser) error {

--- a/internal/volumeserver/snapshot.go
+++ b/internal/volumeserver/snapshot.go
@@ -52,6 +52,8 @@ func (s *Server) getIriSnapshotState(state api.SnapshotState) (iri.VolumeSnapsho
 		return iri.VolumeSnapshotState_VOLUME_SNAPSHOT_READY, nil
 	case api.SnapshotStatePending:
 		return iri.VolumeSnapshotState_VOLUME_SNAPSHOT_PENDING, nil
+	case api.SnapshotStatePopulating, api.SnapshotStateFlattening, api.SnapshotStateFlattened:
+		return iri.VolumeSnapshotState_VOLUME_SNAPSHOT_PENDING, nil
 	case api.SnapshotStateFailed:
 		return iri.VolumeSnapshotState_VOLUME_SNAPSHOT_FAILED, nil
 	default:

--- a/internal/volumeserver/volume.go
+++ b/internal/volumeserver/volume.go
@@ -109,6 +109,8 @@ func (s *Server) getIriState(state api.ImageState) (iri.VolumeState, error) {
 		return iri.VolumeState_VOLUME_AVAILABLE, nil
 	case api.ImageStatePending:
 		return iri.VolumeState_VOLUME_PENDING, nil
+	case api.ImageStateFlatteningChildren:
+		return iri.VolumeState_VOLUME_PENDING, nil
 	default:
 		return 0, fmt.Errorf("unknown volume state '%q'", state)
 	}

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -86,25 +86,20 @@ var _ = BeforeSuite(func() {
 	}()
 	Expect(os.WriteFile(volumeClassesFile.Name(), volumeClassesData, 0666)).To(Succeed())
 
-	opts := app.Options{
-		Address:                    fmt.Sprintf("%s/ceph-volume-provider.sock", os.Getenv("PWD")),
-		PathSupportedVolumeClasses: volumeClassesFile.Name(),
-		Ceph: app.CephOptions{
-			ConnectTimeout:         10 * time.Second,
-			Monitors:               cephMonitors,
-			User:                   cephUsername,
-			KeyringFile:            cephKeyringFilename,
-			Pool:                   cephPoolname,
-			Client:                 cephClientname,
-			KeyEncryptionKeyPath:   keyEncryptionKeyFile.Name(),
-			BurstDurationInSeconds: 15,
-			VolumeEventStoreOptions: eventrecorder.EventStoreOptions{
-				MaxEvents:      maxEvents,
-				TTL:            eventTTL,
-				ResyncInterval: resyncInterval,
-			},
-			WorkerSize: 15,
-		},
+	var opts app.Options
+	opts.Defaults()
+	opts.Address = fmt.Sprintf("%s/ceph-volume-provider.sock", os.Getenv("PWD"))
+	opts.PathSupportedVolumeClasses = volumeClassesFile.Name()
+	opts.Ceph.Monitors = cephMonitors
+	opts.Ceph.User = cephUsername
+	opts.Ceph.KeyringFile = cephKeyringFilename
+	opts.Ceph.Pool = cephPoolname
+	opts.Ceph.Client = cephClientname
+	opts.Ceph.KeyEncryptionKeyPath = keyEncryptionKeyFile.Name()
+	opts.Ceph.VolumeEventStoreOptions = eventrecorder.EventStoreOptions{
+		MaxEvents:      maxEvents,
+		TTL:            eventTTL,
+		ResyncInterval: resyncInterval,
 	}
 
 	srvCtx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added snapshot states: Populating, Flattening, Flattened.
  * Added image state: FlatteningChildren.
  * New async workers/queues for snapshot populate/flatten and image child-flattening with configurable worker-size flags.

* **Refactor**
  * Deletion and cleanup now run asynchronously with persisted intermediate snapshot/image states and queued work.

* **Bug Fixes**
  * Reconciliation short-circuits for in-progress states and treats missing referenced volume images as errors.

* **Tests**
  * Integration startup updated to exercise new worker-size options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/ceph-provider/pull/837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #822 