### PR TITLE
Add checks to see rbd image existence along with store entry

### DIFF
--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -163,6 +163,9 @@ func flattenChildImages(log logr.Logger, conn *rados.Conn, img *librbd.Image) er
 func snapshotExistsAndProtected(log logr.Logger, ioCtx *rados.IOContext, imageName string, snapshotName string) (bool, bool, error) {
 	img, err := openImage(ioCtx, imageName)
 	if err != nil {
+		if errors.Is(err, librbd.ErrNotFound) {
+			return false, false, nil
+		}
 		return false, false, err
 	}
 	defer closeImage(log, img)

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -160,30 +160,41 @@ func flattenChildImages(log logr.Logger, conn *rados.Conn, img *librbd.Image) er
 	return nil
 }
 
-func snapshotExists(log logr.Logger, ioCtx *rados.IOContext, imageName string, snapshotName string) (bool, error) {
+func snapshotExistsAndProtected(log logr.Logger, ioCtx *rados.IOContext, imageName string, snapshotName string) (bool, bool, error) {
 	img, err := openImage(ioCtx, imageName)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	defer closeImage(log, img)
 
 	snapshot := img.GetSnapshot(snapshotName)
 	if isProtected, err := snapshot.IsProtected(); err != nil {
 		if !errors.Is(err, librbd.ErrNotFound) {
-			return false, fmt.Errorf("failed to check if snapshot %s is protected: %w", snapshotName, err)
+			return false, false, fmt.Errorf("failed to check if snapshot %s is protected: %w", snapshotName, err)
 		}
-		return false, err // Snapshot doesn't exist
-	} else if isProtected {
-		log.V(2).Info("Snapshot already exists and is protected", "snapshotName", snapshotName)
-	} else {
-		// Snapshot exists but not protected - just protect it
-		log.V(2).Info("Snapshot exists but is not protected, protecting it", "snapshotName", snapshotName)
-		if err := snapshot.Protect(); err != nil {
-			return false, fmt.Errorf("unable to protect existing snapshot %s: %w", snapshotName, err)
-		}
-		if err := img.SetSnapshot(snapshotName); err != nil {
-			return false, fmt.Errorf("failed to set snapshot %s for image %s: %w", snapshotName, imageName, err)
-		}
+		return false, false, nil
+	} else if !isProtected {
+		log.V(2).Info("Snapshot exists but is not protected", "snapshotId", snapshotName)
+		return true, false, nil
 	}
-	return true, nil
+	log.V(2).Info("Snapshot already exists and is protected", "snapshotId", snapshotName)
+	return true, true, nil
+}
+
+func protectSnapshot(log logr.Logger, ioCtx *rados.IOContext, imageName string, snapshotName string) error {
+	img, err := openImage(ioCtx, imageName)
+	if err != nil {
+		return err
+	}
+	defer closeImage(log, img)
+
+	snapshot := img.GetSnapshot(snapshotName)
+	if err := snapshot.Protect(); err != nil {
+		return fmt.Errorf("unable to protect existing snapshot %s: %w", snapshotName, err)
+	}
+	if err := img.SetSnapshot(snapshotName); err != nil {
+		return fmt.Errorf("failed to set snapshot %s for image %s: %w", snapshotName, imageName, err)
+	}
+	log.V(2).Info("Successfully protected snapshot", "snapshotId", snapshotName)
+	return nil
 }

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -168,11 +168,23 @@ func snapshotExists(log logr.Logger, ioCtx *rados.IOContext, imageName string, s
 	}
 	defer closeImage(log, img)
 
-	if _, err = img.GetSnapID(snapshotName); err != nil {
-		if errors.Is(err, librbd.ErrNotFound) {
-			return false, nil
+	snapshot := img.GetSnapshot(snapshotName)
+	if isProtected, err := snapshot.IsProtected(); err != nil {
+		if !errors.Is(err, librbd.ErrNotFound) {
+			return false, fmt.Errorf("failed to check if snapshot %s is protected: %w", snapshotName, err)
 		}
-		return false, fmt.Errorf("failed to get snapshot ID: %w", err)
+		return false, nil // Snapshot doesn't exist
+	} else if isProtected {
+		log.V(2).Info("Snapshot already exists and is protected, skipping protection.", "snapshotName", snapshotName)
+	} else {
+		// Snapshot exists but not protected - just protect it
+		log.V(2).Info("Snapshot exists but is not protected, protecting it", "snapshotName", snapshotName)
+		if err := snapshot.Protect(); err != nil {
+			return false, fmt.Errorf("unable to protect existing snapshot %s: %w", snapshotName, err)
+		}
+		if err := img.SetSnapshot(snapshotName); err != nil {
+			return false, fmt.Errorf("failed to set snapshot %s for image %s: %w", snapshotName, imageName, err)
+		}
 	}
 	return true, nil
 }

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/ceph/go-ceph/rados"
 	librbd "github.com/ceph/go-ceph/rbd"
@@ -75,7 +76,7 @@ func openImage(ioCtx *rados.IOContext, imageName string) (*librbd.Image, error) 
 	img, err := librbd.OpenImage(ioCtx, imageName, librbd.NoSnapshot)
 	if err != nil {
 		if !errors.Is(err, librbd.ErrNotFound) {
-			return nil, fmt.Errorf("failed to open image: %w", err)
+			return nil, fmt.Errorf("failed to open image %s: %w", imageName, err)
 		}
 		return nil, err
 	}
@@ -87,7 +88,7 @@ func flattenImage(log logr.Logger, conn *rados.Conn, pool string, imageName stri
 
 	ioCtx, err := conn.OpenIOContext(pool)
 	if err != nil {
-		return fmt.Errorf("unable to open io context: %w", err)
+		return fmt.Errorf("unable to open io context for pool %s: %w", pool, err)
 	}
 	defer ioCtx.Destroy()
 
@@ -98,7 +99,7 @@ func flattenImage(log logr.Logger, conn *rados.Conn, pool string, imageName stri
 	defer closeImage(log, img)
 
 	if err := img.Flatten(); err != nil {
-		return fmt.Errorf("failed to flatten cloned image: %w", err)
+		return fmt.Errorf("failed to flatten cloned image %s: %w", imageName, err)
 	}
 	log.V(2).Info("Flattened cloned image", "clonedImageId", imageName)
 	return nil
@@ -113,12 +114,12 @@ func createSnapshot(log logr.Logger, ioCtx *rados.IOContext, snapshotName string
 
 	imgSnap, err := img.CreateSnapshot(snapshotName)
 	if err != nil {
-		return fmt.Errorf("unable to create snapshot: %w", err)
+		return fmt.Errorf("unable to create snapshot %s: %w", snapshotName, err)
 	}
 	log.Info("Snapshot created")
 
 	if err := imgSnap.Protect(); err != nil {
-		return fmt.Errorf("unable to protect snapshot: %w", err)
+		return fmt.Errorf("unable to protect snapshot %s: %w", snapshotName, err)
 	}
 
 	if err := img.SetSnapshot(snapshotName); err != nil {
@@ -174,4 +175,17 @@ func snapshotExists(log logr.Logger, ioCtx *rados.IOContext, imageName string, s
 		return false, fmt.Errorf("failed to get snapshot ID: %w", err)
 	}
 	return true, nil
+}
+
+func isRbdImageExisting(ioCtx *rados.IOContext, imageID string) (bool, error) {
+	images, err := librbd.GetImageNames(ioCtx)
+	if err != nil {
+		return false, fmt.Errorf("failed to list images: %w", err)
+	}
+
+	if slices.Contains(images, imageID) {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -6,7 +6,6 @@ package controllers
 import (
 	"errors"
 	"fmt"
-	"slices"
 
 	"github.com/ceph/go-ceph/rados"
 	librbd "github.com/ceph/go-ceph/rbd"
@@ -173,9 +172,9 @@ func snapshotExists(log logr.Logger, ioCtx *rados.IOContext, imageName string, s
 		if !errors.Is(err, librbd.ErrNotFound) {
 			return false, fmt.Errorf("failed to check if snapshot %s is protected: %w", snapshotName, err)
 		}
-		return false, nil // Snapshot doesn't exist
+		return false, err // Snapshot doesn't exist
 	} else if isProtected {
-		log.V(2).Info("Snapshot already exists and is protected, skipping protection.", "snapshotName", snapshotName)
+		log.V(2).Info("Snapshot already exists and is protected", "snapshotName", snapshotName)
 	} else {
 		// Snapshot exists but not protected - just protect it
 		log.V(2).Info("Snapshot exists but is not protected, protecting it", "snapshotName", snapshotName)
@@ -187,17 +186,4 @@ func snapshotExists(log logr.Logger, ioCtx *rados.IOContext, imageName string, s
 		}
 	}
 	return true, nil
-}
-
-func isRbdImageExisting(ioCtx *rados.IOContext, imageID string) (bool, error) {
-	images, err := librbd.GetImageNames(ioCtx)
-	if err != nil {
-		return false, fmt.Errorf("failed to list images: %w", err)
-	}
-
-	if slices.Contains(images, imageID) {
-		return true, nil
-	}
-
-	return false, nil
 }

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -269,9 +269,15 @@ func (r *ImageReconciler) deleteImageSnapshots(ctx context.Context, log logr.Log
 			return fmt.Errorf("failed to create snapshot clone: %w", err)
 		}
 
-		if isSnapshotExist, err := snapshotExists(log, ioCtx, ImageIDToRBDID(snapName), snapName); err != nil && !errors.Is(err, librbd.ErrNotFound) {
+		if isSnapshotExist, isSnapshotProtected, err := snapshotExistsAndProtected(log, ioCtx, ImageIDToRBDID(snapName), snapName); err != nil {
 			return fmt.Errorf("failed to check if snapshot %s exists: %w", snapName, err)
 		} else if isSnapshotExist {
+			if !isSnapshotProtected {
+				// Snapshot exists but not protected - just protect it
+				if err := protectSnapshot(log, ioCtx, ImageIDToRBDID(snapName), snapName); err != nil {
+					return fmt.Errorf("failed to protect snapshot: %w", err)
+				}
+			}
 			log.V(2).Info("Snapshot of cloned image is already created")
 			continue
 		}
@@ -597,7 +603,7 @@ func (r *ImageReconciler) reconcileImage(ctx context.Context, id string) error {
 		switch {
 		case img.Spec.SnapshotRef != nil:
 			snapshotRef := img.Spec.SnapshotRef
-			log.V(2).Info("Creating image from snapshot", "snapshotRef", snapshotRef)
+			log.V(2).Info("Creating image from snapshot", "snapshotId", snapshotRef)
 			ok, err := r.createImageFromSnapshot(ctx, log, ioCtx, img, *snapshotRef, options)
 			if err != nil {
 				return fmt.Errorf("failed to create image from snapshot: %w", err)
@@ -740,7 +746,7 @@ func (r *ImageReconciler) createImageFromSnapshot(ctx context.Context, log logr.
 			return false, fmt.Errorf("failed to get snapshot: %w", err)
 		}
 
-		log.V(1).Info("snapshot not found", "snapshotID", snapshotRef)
+		log.V(1).Info("snapshot not found", "snapshotId", snapshotRef)
 		return false, nil
 	}
 
@@ -754,18 +760,19 @@ func (r *ImageReconciler) createImageFromSnapshot(ctx context.Context, log logr.
 		return false, fmt.Errorf("failed to get snapshot source details: %w", err)
 	}
 
-	log.V(2).Info("Check if rbd snapshot exists")
-	if isSnapshotExist, err := snapshotExists(log, ioCtx, parentName, snapName); err != nil && !errors.Is(err, librbd.ErrNotFound) {
+	log.V(2).Info("Check if rbd snapshot exists", "snapshotId", snapName)
+	isSnapshotExist, isSnapshotProtected, err := snapshotExistsAndProtected(log, ioCtx, parentName, snapName)
+	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
 		return false, fmt.Errorf("failed to check volume image snapshot existence: %w", err)
-	} else if !isSnapshotExist && snapshot.Status.State == providerapi.SnapshotStateReady {
-		log.V(1).Info("Rbd snapshot does not exist. Mark snapshot as failed", "snapshotName", snapName)
+	} else if !isSnapshotExist || !isSnapshotProtected {
+		log.V(1).Info("Rbd snapshot does not exist or not protected. Mark snapshot as failed", "snapshotName", snapName)
 		snapshot.Status.State = providerapi.SnapshotStateFailed
 		if _, err := r.snapshots.Update(ctx, snapshot); store.IgnoreErrNotFound(err) != nil {
 			return false, fmt.Errorf("failed to update snapshot state: %w", err)
 		}
 		return false, nil
 	}
-	log.V(2).Info("Rbd snapshot exists", "snapshotName", snapName)
+	log.V(2).Info("Checked rbd snapshot existence", "snapshotId", snapName, "isSnapshotExist", isSnapshotExist)
 
 	ioCtx2, err := r.conn.OpenIOContext(r.pool)
 	if err != nil {

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -269,7 +269,10 @@ func (r *ImageReconciler) deleteImageSnapshots(ctx context.Context, log logr.Log
 			return fmt.Errorf("failed to create snapshot clone: %w", err)
 		}
 
-		if isSnapshotExist, err := snapshotExists(log, ioCtx, ImageIDToRBDID(snapName), snapName); err == nil && isSnapshotExist {
+		if isSnapshotExist, err := snapshotExists(log, ioCtx, ImageIDToRBDID(snapName), snapName); err != nil {
+			return fmt.Errorf("failed to check if snapshot %s exists: %w", snapName, err)
+		} else if isSnapshotExist {
+			log.V(2).Info("Snapshot of cloned image is already created")
 			continue
 		}
 
@@ -746,28 +749,23 @@ func (r *ImageReconciler) createImageFromSnapshot(ctx context.Context, log logr.
 		return false, nil
 	}
 
-	if image.Spec.Image != "" {
-		log.V(2).Info("Check if snapshot rbd image already exist")
-		imageExists, err := isRbdImageExisting(ioCtx, SnapshotIDToRBDID(snapshotRef))
-		if err != nil {
-			return false, fmt.Errorf("failed to check snapshot rbd image existence: %w", err)
-		}
-		log.V(1).Info("Checked snapshot rbd image existence", "imageExists", imageExists)
-
-		if !imageExists && snapshot.Status.State == providerapi.SnapshotStateReady {
-			log.V(1).Info("Snapshot rbd image does not exist. Mark snapshot as failed to trigger rbd image creation in next reconciliation loop")
-			snapshot.Status.State = providerapi.SnapshotStateFailed
-			if _, err := r.snapshots.Update(ctx, snapshot); store.IgnoreErrNotFound(err) != nil {
-				return false, fmt.Errorf("failed to update snapshot to trigger rbd image creation: %w", err)
-			}
-			return false, nil
-		}
-	}
-
 	parentName, snapName, err := getSnapshotSourceDetails(snapshot)
 	if err != nil {
 		return false, fmt.Errorf("failed to get snapshot source details: %w", err)
 	}
+
+	log.V(2).Info("Check if rbd snapshot exists")
+	if isSnapshotExist, err := snapshotExists(log, ioCtx, parentName, snapName); err != nil && !errors.Is(err, librbd.ErrNotFound) {
+		return false, fmt.Errorf("failed to check volume image snapshot existence: %w", err)
+	} else if !isSnapshotExist && snapshot.Status.State == providerapi.SnapshotStateReady {
+		log.V(1).Info("Rbd snapshot does not exist. Mark snapshot as failed", "snapshotName", snapName)
+		snapshot.Status.State = providerapi.SnapshotStateFailed
+		if _, err := r.snapshots.Update(ctx, snapshot); store.IgnoreErrNotFound(err) != nil {
+			return false, fmt.Errorf("failed to update snapshot state: %w", err)
+		}
+		return false, nil
+	}
+	log.V(2).Info("Rbd snapshot exists", "snapshotName", snapName)
 
 	ioCtx2, err := r.conn.OpenIOContext(r.pool)
 	if err != nil {

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -603,7 +603,7 @@ func (r *ImageReconciler) reconcileImage(ctx context.Context, id string) error {
 		switch {
 		case img.Spec.SnapshotRef != nil:
 			snapshotRef := img.Spec.SnapshotRef
-			log.V(2).Info("Creating image from snapshot", "snapshotId", snapshotRef)
+			log.V(2).Info("Creating image from snapshot", "snapshotId", *snapshotRef)
 			ok, err := r.createImageFromSnapshot(ctx, log, ioCtx, img, *snapshotRef, options)
 			if err != nil {
 				return fmt.Errorf("failed to create image from snapshot: %w", err)
@@ -764,7 +764,14 @@ func (r *ImageReconciler) createImageFromSnapshot(ctx context.Context, log logr.
 	isSnapshotExist, isSnapshotProtected, err := snapshotExistsAndProtected(log, ioCtx, parentName, snapName)
 	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
 		return false, fmt.Errorf("failed to check volume image snapshot existence: %w", err)
-	} else if !isSnapshotExist || !isSnapshotProtected {
+	}
+	if isSnapshotExist && !isSnapshotProtected {
+		if err := protectSnapshot(log, ioCtx, parentName, snapName); err != nil {
+			return false, fmt.Errorf("failed to protect snapshot %s: %w", snapName, err)
+		}
+		isSnapshotProtected = true
+	}
+	if !isSnapshotExist {
 		log.V(1).Info("Rbd snapshot does not exist or not protected. Mark snapshot as failed", "snapshotName", snapName)
 		snapshot.Status.State = providerapi.SnapshotStateFailed
 		if _, err := r.snapshots.Update(ctx, snapshot); store.IgnoreErrNotFound(err) != nil {

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -771,7 +771,7 @@ func (r *ImageReconciler) createImageFromSnapshot(ctx context.Context, log logr.
 		}
 	}
 	if !isSnapshotExist {
-		log.V(1).Info("Rbd snapshot does not exist or not protected. Mark snapshot as failed", "snapshotName", snapName)
+		log.V(1).Info("Rbd snapshot does not exist. Mark snapshot as failed", "snapshotName", snapName)
 		snapshot.Status.State = providerapi.SnapshotStateFailed
 		if _, err := r.snapshots.Update(ctx, snapshot); store.IgnoreErrNotFound(err) != nil {
 			return false, fmt.Errorf("failed to update snapshot state: %w", err)

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -742,13 +742,30 @@ func (r *ImageReconciler) createImageFromSnapshot(ctx context.Context, log logr.
 		}
 
 		log.V(1).Info("snapshot not found", "snapshotID", snapshotRef)
-
 		return false, nil
 	}
 
 	if snapshot.Status.State != providerapi.SnapshotStateReady && snapshot.Status.State != providerapi.SnapshotStatePopulated {
 		log.V(1).Info("snapshot is not populated", "state", snapshot.Status.State)
 		return false, nil
+	}
+
+	if image.Spec.Image != "" {
+		log.V(2).Info("Check if snapshot rbd image already exist")
+		imageExists, err := isRbdImageExisting(ioCtx, SnapshotIDToRBDID(snapshotRef))
+		if err != nil {
+			return false, fmt.Errorf("failed to check snapshot rbd image existence: %w", err)
+		}
+		log.V(1).Info("Checked snapshot rbd image existence", "imageExists", imageExists)
+
+		if !imageExists && snapshot.Status.State == providerapi.SnapshotStateReady {
+			log.V(1).Info("Snapshot rbd image does not exist. Mark snapshot as failed to trigger rbd image creation in next reconciliation loop")
+			snapshot.Status.State = providerapi.SnapshotStateFailed
+			if _, err := r.snapshots.Update(ctx, snapshot); store.IgnoreErrNotFound(err) != nil {
+				return false, fmt.Errorf("failed to update snapshot to trigger rbd image creation: %w", err)
+			}
+			return false, nil
+		}
 	}
 
 	parentName, snapName, err := getSnapshotSourceDetails(snapshot)

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -269,7 +269,7 @@ func (r *ImageReconciler) deleteImageSnapshots(ctx context.Context, log logr.Log
 			return fmt.Errorf("failed to create snapshot clone: %w", err)
 		}
 
-		if isSnapshotExist, err := snapshotExists(log, ioCtx, ImageIDToRBDID(snapName), snapName); err != nil {
+		if isSnapshotExist, err := snapshotExists(log, ioCtx, ImageIDToRBDID(snapName), snapName); err != nil && !errors.Is(err, librbd.ErrNotFound) {
 			return fmt.Errorf("failed to check if snapshot %s exists: %w", snapName, err)
 		} else if isSnapshotExist {
 			log.V(2).Info("Snapshot of cloned image is already created")

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -767,13 +767,14 @@ func (r *ImageReconciler) createImageFromSnapshot(ctx context.Context, log logr.
 
 	log.V(2).Info("Check if rbd snapshot exists", "snapshotId", snapName)
 	isSnapshotExist, isSnapshotProtected, err := snapshotExistsAndProtected(log, ioCtx, parentName, snapName)
-	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
+	if err != nil {
 		return false, fmt.Errorf("failed to check volume image snapshot existence: %w", err)
 	}
 	if isSnapshotExist && !isSnapshotProtected {
 		if err := protectSnapshot(log, ioCtx, parentName, snapName); err != nil {
 			return false, fmt.Errorf("failed to protect snapshot %s: %w", snapName, err)
 		}
+		isSnapshotExist = true
 	}
 	if !isSnapshotExist {
 		log.V(1).Info("Rbd snapshot does not exist. Mark snapshot as failed", "snapshotName", snapName)

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -269,14 +269,10 @@ func (r *ImageReconciler) deleteImageSnapshots(ctx context.Context, log logr.Log
 			return fmt.Errorf("failed to create snapshot clone: %w", err)
 		}
 
-		isSnapshotExist, err := snapshotExists(log, ioCtx, ImageIDToRBDID(snapName), snapName)
-		if err != nil {
-			return fmt.Errorf("failed to check if snapshot exists: %w", err)
-		}
-		if isSnapshotExist {
-			log.V(2).Info("Snapshot of cloned image is already created")
+		if isSnapshotExist, err := snapshotExists(log, ioCtx, ImageIDToRBDID(snapName), snapName); err == nil && isSnapshotExist {
 			continue
 		}
+
 		log.V(2).Info("Create snapshot of cloned image", "clonedImageId", snapName)
 		if err := createSnapshot(log, ioCtx, snapName, ImageIDToRBDID(snapName)); err != nil {
 			return fmt.Errorf("failed to create snapshot of cloned image: %w", err)

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -750,6 +750,11 @@ func (r *ImageReconciler) createImageFromSnapshot(ctx context.Context, log logr.
 		return false, nil
 	}
 
+	if snapshot.Status.Size > int64(image.Spec.Size) {
+		r.Eventf(image.Metadata, corev1.EventTypeWarning, "ImageSizeIsSmallerThanSnapshotSize", "image %s size is smaller than snapshot size: %d < %d", image.ID, image.Spec.Size, snapshot.Status.Size)
+		return false, fmt.Errorf("image %s size is smaller than snapshot size: (%d < %d)", image.ID, image.Spec.Size, snapshot.Status.Size)
+	}
+
 	if snapshot.Status.State != providerapi.SnapshotStateReady && snapshot.Status.State != providerapi.SnapshotStatePopulated {
 		log.V(1).Info("snapshot is not populated", "state", snapshot.Status.State)
 		return false, nil

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -769,7 +769,6 @@ func (r *ImageReconciler) createImageFromSnapshot(ctx context.Context, log logr.
 		if err := protectSnapshot(log, ioCtx, parentName, snapName); err != nil {
 			return false, fmt.Errorf("failed to protect snapshot %s: %w", snapName, err)
 		}
-		isSnapshotProtected = true
 	}
 	if !isSnapshotExist {
 		log.V(1).Info("Rbd snapshot does not exist or not protected. Mark snapshot as failed", "snapshotName", snapName)

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -249,21 +249,35 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 		return nil
 	}
 
-	// SnapshotStatePopulated is no longer actively used. It has been replaced by SnapshotStateReady.
-	// This block will transition any snapshots that are in SnapshotStatePopulated to SnapshotStateReady.
-	if snapshot.Status.State == providerapi.SnapshotStatePopulated {
-		log.V(1).Info("Snapshot already populated")
-		snapshot.Status.State = providerapi.SnapshotStateReady
-		if _, err = r.store.Update(ctx, snapshot); err != nil {
-			return fmt.Errorf("failed to update snapshot: %w", err)
+	imageExists := false
+	log.V(2).Info("Check if snapshot image already exist")
+	if snapshot.Source.IronCoreImage != "" {
+		imageExists, err = isRbdImageExisting(ioCtx, SnapshotIDToRBDID(snapshot.ID))
+	} else if snapshot.Source.VolumeImageID != "" {
+		imageExists, err = snapshotExists(log, ioCtx, ImageIDToRBDID(snapshot.Source.VolumeImageID), snapshot.ID)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to check if snapshot exists: %w", err)
+	}
+	log.V(1).Info("Checked snapshot rbd image existence", "imageExists", imageExists)
+
+	if imageExists {
+		// SnapshotStatePopulated is no longer actively used. It has been replaced by SnapshotStateReady.
+		// This block will transition any snapshots that are in SnapshotStatePopulated to SnapshotStateReady.
+		if snapshot.Status.State == providerapi.SnapshotStatePopulated {
+			log.V(1).Info("Snapshot already populated")
+			snapshot.Status.State = providerapi.SnapshotStateReady
+			if _, err = r.store.Update(ctx, snapshot); err != nil {
+				return fmt.Errorf("failed to update snapshot: %w", err)
+			}
+
+			return nil
 		}
 
-		return nil
-	}
-
-	if snapshot.Status.State == providerapi.SnapshotStateReady {
-		log.V(1).Info("Snapshot is ready")
-		return nil
+		if snapshot.Status.State == providerapi.SnapshotStateReady {
+			log.V(1).Info("Snapshot is ready")
+			return nil
+		}
 	}
 
 	if !slices.Contains(snapshot.Finalizers, SnapshotFinalizer) {
@@ -325,20 +339,24 @@ func (r *SnapshotReconciler) reconcileIroncoreImageSnapshot(ctx context.Context,
 	}
 	log.V(2).Info("Configured pool", "pool", r.pool)
 
-	imageName := SnapshotIDToRBDID(snapshot.ID)
+	rbdImageID := SnapshotIDToRBDID(snapshot.ID)
 	roundedSize := round.OffBytes(snapshotSize)
-	if err = librbd.CreateImage(ioCtx, imageName, roundedSize, options); err != nil {
-		return fmt.Errorf("failed to create os rbd image: %w", err)
-	}
-	log.V(2).Info("Created rbd image", "bytes", roundedSize)
 
-	if err := r.prepareSnapshotContent(log, ioCtx, imageName, rc); err != nil {
+	rbdImg, err := openImage(ioCtx, rbdImageID)
+	if errors.Is(err, librbd.ErrNotFound) {
+		if err = librbd.CreateImage(ioCtx, rbdImageID, roundedSize, options); err != nil {
+			return fmt.Errorf("failed to create os rbd image: %w", err)
+		}
+		log.V(2).Info("Created rbd image", "bytes", roundedSize)
+		rbdImg, err = openImage(ioCtx, rbdImageID)
+	}
+	if err != nil {
+		return err
+	}
+	defer closeImage(log, rbdImg)
+
+	if err := r.prepareSnapshotContent(log, ioCtx, rbdImg, rc); err != nil {
 		return fmt.Errorf("failed to prepare snapshot content: %w", err)
-	}
-
-	log.V(2).Info("Create ironcore image snapshot", "ImageID", imageName)
-	if err := createSnapshot(log, ioCtx, ImageSnapshotVersion, imageName); err != nil {
-		return fmt.Errorf("failed to create ironcore image snapshot: %w", err)
 	}
 
 	snapshot.Status.Digest = digest
@@ -393,17 +411,27 @@ func (r *SnapshotReconciler) openIroncoreImageSource(ctx context.Context, imageR
 	return content, uint64(rootFS.Descriptor().Size), img.Descriptor().Digest.String(), nil
 }
 
-func (r *SnapshotReconciler) prepareSnapshotContent(log logr.Logger, ioCtx *rados.IOContext, imageName string, rc io.ReadCloser) error {
-	rbdImg, err := openImage(ioCtx, imageName)
-	if err != nil {
-		return err
+func (r *SnapshotReconciler) prepareSnapshotContent(log logr.Logger, ioCtx *rados.IOContext, rbdImg *librbd.Image, rc io.ReadCloser) error {
+	rbdImageID := rbdImg.GetName()
+	currentSnap := rbdImg.GetSnapshot(ImageSnapshotVersion)
+	if isProtected, err := currentSnap.IsProtected(); err != nil {
+		if !errors.Is(err, librbd.ErrNotFound) {
+			return fmt.Errorf("failed to check if snapshot %s is protected: %w", ImageSnapshotVersion, err)
+		}
+	} else if isProtected {
+		log.V(2).Info("Snapshot already exists and is protected, skipping creation and protection.", "snapshotName", ImageSnapshotVersion)
+		return nil
 	}
-	defer closeImage(log, rbdImg)
 
 	if err := r.populateImage(log, rbdImg, rc); err != nil {
 		return fmt.Errorf("failed to populate os image: %w", err)
 	}
 	log.V(2).Info("Populated os image on rbd image")
+
+	log.V(2).Info("Create ironcore image snapshot", "ImageID", rbdImageID)
+	if err := createSnapshot(log, ioCtx, ImageSnapshotVersion, rbdImageID); err != nil {
+		return fmt.Errorf("failed to create ironcore image snapshot: %w", err)
+	}
 
 	return nil
 }

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -249,19 +249,29 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 		return nil
 	}
 
-	imageExists := false
-	if snapshot.Source.IronCoreImage != "" {
-		log.V(2).Info("Check if snapshot image already exist")
-		imageExists, err = isRbdImageExisting(ioCtx, SnapshotIDToRBDID(snapshot.ID))
-		if err != nil {
-			return fmt.Errorf("failed to check if snapshot exists: %w", err)
+	if !slices.Contains(snapshot.Finalizers, SnapshotFinalizer) {
+		snapshot.Finalizers = append(snapshot.Finalizers, SnapshotFinalizer)
+		if _, err := r.store.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to set finalizers: %w", err)
 		}
-		log.V(1).Info("Checked snapshot rbd image existence", "imageExists", imageExists)
-	} else if snapshot.Source.VolumeImageID != "" {
-		imageExists = true
 	}
 
-	if imageExists {
+	rbdID, snapshotID, err := getSnapshotSourceDetails(snapshot)
+	if err != nil {
+		return fmt.Errorf("failed to get snapshot source details: %w", err)
+	}
+
+	log.V(2).Info("Check if rbd snapshot exists")
+	isSnapshotExist, err := snapshotExists(log, ioCtx, rbdID, snapshotID)
+	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
+		snapshot.Status.State = providerapi.SnapshotStateFailed
+		if _, err = r.store.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to update snapshot: %w", err)
+		}
+		return fmt.Errorf("failed to check snapshot existence: %w", err)
+	}
+
+	if isSnapshotExist {
 		// SnapshotStatePopulated is no longer actively used. It has been replaced by SnapshotStateReady.
 		// This block will transition any snapshots that are in SnapshotStatePopulated to SnapshotStateReady.
 		if snapshot.Status.State == providerapi.SnapshotStatePopulated {
@@ -270,7 +280,6 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 			if _, err = r.store.Update(ctx, snapshot); err != nil {
 				return fmt.Errorf("failed to update snapshot: %w", err)
 			}
-
 			return nil
 		}
 
@@ -278,29 +287,27 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 			log.V(1).Info("Snapshot is ready")
 			return nil
 		}
-	}
-
-	if !slices.Contains(snapshot.Finalizers, SnapshotFinalizer) {
-		snapshot.Finalizers = append(snapshot.Finalizers, SnapshotFinalizer)
-		if _, err := r.store.Update(ctx, snapshot); err != nil {
-			return fmt.Errorf("failed to set finalizers: %w", err)
+	} else {
+		log.V(1).Info("Rbd snapshot does not exist, start reconciliation")
+		switch {
+		case snapshot.Source.IronCoreImage != "":
+			err = r.reconcileIroncoreImageSnapshot(ctx, log, ioCtx, snapshot)
+		case snapshot.Source.VolumeImageID != "":
+			if snapshot.Status.State == providerapi.SnapshotStateFailed {
+				log.V(1).Info("Skipping snapshot creation", "reason", "Snapshot is failed after creation due to missing rbd snapshot")
+				return nil
+			}
+			err = r.reconcileVolumeImageSnapshot(ctx, log, ioCtx, snapshot)
+		default:
+			return fmt.Errorf("snapshot source not found")
 		}
-	}
-
-	switch {
-	case snapshot.Source.IronCoreImage != "":
-		err = r.reconcileIroncoreImageSnapshot(ctx, log, ioCtx, snapshot)
-	case snapshot.Source.VolumeImageID != "":
-		err = r.reconcileVolumeImageSnapshot(ctx, log, ioCtx, snapshot)
-	default:
-		return fmt.Errorf("snapshot source not found")
-	}
-	if err != nil {
-		snapshot.Status.State = providerapi.SnapshotStateFailed
-		if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
-			return errors.Join(err, fmt.Errorf("failed to update snapshot state: %w", updateErr))
+		if err != nil {
+			snapshot.Status.State = providerapi.SnapshotStateFailed
+			if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
+				return errors.Join(err, fmt.Errorf("failed to update snapshot state: %w", updateErr))
+			}
+			return fmt.Errorf("failed to reconcile snapshot: %w", err)
 		}
-		return fmt.Errorf("failed to reconcile snapshot: %w", err)
 	}
 
 	snapshot.Status.State = providerapi.SnapshotStateReady
@@ -373,10 +380,6 @@ func (r *SnapshotReconciler) reconcileVolumeImageSnapshot(ctx context.Context, l
 		return nil
 	}
 
-	if isSnapshotExist, err := snapshotExists(log, ioCtx, img.GetID(), snapshot.ID); err == nil && isSnapshotExist {
-		return nil
-	}
-
 	log.V(2).Info("Create volume image snapshot", "ImageID", img.ID)
 	if err := createSnapshot(log, ioCtx, snapshot.ID, ImageIDToRBDID(img.ID)); err != nil {
 		return fmt.Errorf("failed to create volume image snapshot: %w", err)
@@ -417,9 +420,6 @@ func (r *SnapshotReconciler) openIroncoreImageSource(ctx context.Context, imageR
 
 func (r *SnapshotReconciler) prepareSnapshotContent(log logr.Logger, ioCtx *rados.IOContext, rbdImg *librbd.Image, rc io.ReadCloser) error {
 	rbdImageID := rbdImg.GetName()
-	if isSnapshotExist, err := snapshotExists(log, ioCtx, rbdImageID, ImageSnapshotVersion); err == nil && isSnapshotExist {
-		return nil
-	}
 
 	if err := r.populateImage(log, rbdImg, rc); err != nil {
 		return fmt.Errorf("failed to populate os image: %w", err)

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -263,58 +263,53 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 
 	log.V(2).Info("Check if rbd snapshot exists")
 	isSnapshotExist, isSnapshotProtected, err := snapshotExistsAndProtected(log, ioCtx, rbdID, snapshotID)
-	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
-		snapshot.Status.State = providerapi.SnapshotStateFailed
-		if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
-			return errors.Join(err, fmt.Errorf("failed to update snapshot: %w", updateErr))
-		}
+	if err != nil {
 		return fmt.Errorf("failed to check snapshot existence: %w", err)
 	}
 
-	if isSnapshotExist {
-		if !isSnapshotProtected {
-			// Snapshot exists but not protected - just protect it
-			if err := protectSnapshot(log, ioCtx, rbdID, snapshotID); err != nil {
-				return fmt.Errorf("failed to protect snapshot: %w", err)
-			}
+	if isSnapshotExist && !isSnapshotProtected {
+		// Snapshot exists but not protected - just protect it
+		if err := protectSnapshot(log, ioCtx, rbdID, snapshotID); err != nil {
+			return fmt.Errorf("failed to protect snapshot: %w", err)
 		}
+	}
 
-		// SnapshotStatePopulated is no longer actively used. It has been replaced by SnapshotStateReady.
-		// This block will transition any snapshots that are in SnapshotStatePopulated to SnapshotStateReady.
-		if snapshot.Status.State == providerapi.SnapshotStatePopulated {
-			log.V(1).Info("Snapshot already populated")
-			snapshot.Status.State = providerapi.SnapshotStateReady
-			if _, err = r.store.Update(ctx, snapshot); err != nil {
-				return fmt.Errorf("failed to update snapshot: %w", err)
-			}
-			return nil
+	// SnapshotStatePopulated is no longer actively used. It has been replaced by SnapshotStateReady.
+	// This block will transition any snapshots that are in SnapshotStatePopulated to SnapshotStateReady.
+	if snapshot.Status.State == providerapi.SnapshotStatePopulated {
+		log.V(1).Info("Snapshot already populated")
+		snapshot.Status.State = providerapi.SnapshotStateReady
+		if _, err = r.store.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to update snapshot: %w", err)
 		}
+		return nil
+	}
 
-		if snapshot.Status.State == providerapi.SnapshotStateReady {
-			log.V(1).Info("Snapshot is ready")
-			return nil
+	if snapshot.Status.State == providerapi.SnapshotStateReady {
+		log.V(1).Info("Snapshot is ready")
+		return nil
+	}
+
+	if snapshot.Status.State == providerapi.SnapshotStateFailed {
+		log.V(1).Info("Rbd snapshot does not exist, so snapshot in store is marked as failed")
+		return nil
+	}
+
+	log.V(1).Info("Rbd snapshot does not exist, start reconciliation")
+	switch {
+	case snapshot.Source.IronCoreImage != "":
+		err = r.reconcileIroncoreImageSnapshot(ctx, log, ioCtx, snapshot)
+	case snapshot.Source.VolumeImageID != "":
+		err = r.reconcileVolumeImageSnapshot(ctx, log, ioCtx, snapshot)
+	default:
+		return fmt.Errorf("snapshot source not found")
+	}
+	if err != nil {
+		snapshot.Status.State = providerapi.SnapshotStateFailed
+		if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
+			return errors.Join(err, fmt.Errorf("failed to update snapshot state: %w", updateErr))
 		}
-	} else {
-		log.V(1).Info("Rbd snapshot does not exist, start reconciliation")
-		switch {
-		case snapshot.Source.IronCoreImage != "":
-			err = r.reconcileIroncoreImageSnapshot(ctx, log, ioCtx, snapshot)
-		case snapshot.Source.VolumeImageID != "":
-			if snapshot.Status.State == providerapi.SnapshotStateFailed {
-				log.V(1).Info("Skipping snapshot creation: source volume RBD image snapshot was deleted, snapshot cannot be recreated")
-				return nil
-			}
-			err = r.reconcileVolumeImageSnapshot(ctx, log, ioCtx, snapshot)
-		default:
-			return fmt.Errorf("snapshot source not found")
-		}
-		if err != nil {
-			snapshot.Status.State = providerapi.SnapshotStateFailed
-			if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
-				return errors.Join(err, fmt.Errorf("failed to update snapshot state: %w", updateErr))
-			}
-			return fmt.Errorf("failed to reconcile snapshot: %w", err)
-		}
+		return fmt.Errorf("failed to reconcile snapshot: %w", err)
 	}
 
 	snapshot.Status.State = providerapi.SnapshotStateReady
@@ -356,21 +351,18 @@ func (r *SnapshotReconciler) reconcileIroncoreImageSnapshot(ctx context.Context,
 	rbdImageID := SnapshotIDToRBDID(snapshot.ID)
 	roundedSize := round.OffBytes(snapshotSize)
 
-	rbdImg, err := openImage(ioCtx, rbdImageID)
-	if errors.Is(err, librbd.ErrNotFound) {
-		if err = librbd.CreateImage(ioCtx, rbdImageID, roundedSize, options); err != nil {
-			return fmt.Errorf("failed to create os rbd image: %w", err)
-		}
-		log.V(2).Info("Created rbd image", "bytes", roundedSize)
-		rbdImg, err = openImage(ioCtx, rbdImageID)
+	if err = librbd.CreateImage(ioCtx, rbdImageID, roundedSize, options); err != nil {
+		return fmt.Errorf("failed to create os rbd image: %w", err)
 	}
-	if err != nil {
-		return err
-	}
-	defer closeImage(log, rbdImg)
+	log.V(2).Info("Created rbd image", "bytes", roundedSize)
 
-	if err := r.prepareSnapshotContent(log, ioCtx, rbdImg, rc); err != nil {
+	if err := r.prepareSnapshotContent(log, ioCtx, rbdImageID, rc); err != nil {
 		return fmt.Errorf("failed to prepare snapshot content: %w", err)
+	}
+
+	log.V(2).Info("Create ironcore image snapshot", "ImageID", rbdImageID)
+	if err := createSnapshot(log, ioCtx, ImageSnapshotVersion, rbdImageID); err != nil {
+		return fmt.Errorf("failed to create ironcore image snapshot: %w", err)
 	}
 
 	snapshot.Status.Digest = digest
@@ -425,18 +417,17 @@ func (r *SnapshotReconciler) openIroncoreImageSource(ctx context.Context, imageR
 	return content, uint64(rootFS.Descriptor().Size), img.Descriptor().Digest.String(), nil
 }
 
-func (r *SnapshotReconciler) prepareSnapshotContent(log logr.Logger, ioCtx *rados.IOContext, rbdImg *librbd.Image, rc io.ReadCloser) error {
-	rbdImageID := rbdImg.GetName()
+func (r *SnapshotReconciler) prepareSnapshotContent(log logr.Logger, ioCtx *rados.IOContext, imageName string, rc io.ReadCloser) error {
+	rbdImg, err := openImage(ioCtx, imageName)
+	if err != nil {
+		return err
+	}
+	defer closeImage(log, rbdImg)
 
 	if err := r.populateImage(log, rbdImg, rc); err != nil {
 		return fmt.Errorf("failed to populate os image: %w", err)
 	}
 	log.V(2).Info("Populated os image on rbd image")
-
-	log.V(2).Info("Create ironcore image snapshot", "ImageID", rbdImageID)
-	if err := createSnapshot(log, ioCtx, ImageSnapshotVersion, rbdImageID); err != nil {
-		return fmt.Errorf("failed to create ironcore image snapshot: %w", err)
-	}
 
 	return nil
 }

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -250,16 +250,16 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 	}
 
 	imageExists := false
-	log.V(2).Info("Check if snapshot image already exist")
 	if snapshot.Source.IronCoreImage != "" {
+		log.V(2).Info("Check if snapshot image already exist")
 		imageExists, err = isRbdImageExisting(ioCtx, SnapshotIDToRBDID(snapshot.ID))
+		if err != nil {
+			return fmt.Errorf("failed to check if snapshot exists: %w", err)
+		}
+		log.V(1).Info("Checked snapshot rbd image existence", "imageExists", imageExists)
 	} else if snapshot.Source.VolumeImageID != "" {
-		imageExists, err = snapshotExists(log, ioCtx, ImageIDToRBDID(snapshot.Source.VolumeImageID), snapshot.ID)
+		imageExists = true
 	}
-	if err != nil {
-		return fmt.Errorf("failed to check if snapshot exists: %w", err)
-	}
-	log.V(1).Info("Checked snapshot rbd image existence", "imageExists", imageExists)
 
 	if imageExists {
 		// SnapshotStatePopulated is no longer actively used. It has been replaced by SnapshotStateReady.
@@ -373,6 +373,10 @@ func (r *SnapshotReconciler) reconcileVolumeImageSnapshot(ctx context.Context, l
 		return nil
 	}
 
+	if isSnapshotExist, err := snapshotExists(log, ioCtx, img.GetID(), snapshot.ID); err == nil && isSnapshotExist {
+		return nil
+	}
+
 	log.V(2).Info("Create volume image snapshot", "ImageID", img.ID)
 	if err := createSnapshot(log, ioCtx, snapshot.ID, ImageIDToRBDID(img.ID)); err != nil {
 		return fmt.Errorf("failed to create volume image snapshot: %w", err)
@@ -413,13 +417,7 @@ func (r *SnapshotReconciler) openIroncoreImageSource(ctx context.Context, imageR
 
 func (r *SnapshotReconciler) prepareSnapshotContent(log logr.Logger, ioCtx *rados.IOContext, rbdImg *librbd.Image, rc io.ReadCloser) error {
 	rbdImageID := rbdImg.GetName()
-	currentSnap := rbdImg.GetSnapshot(ImageSnapshotVersion)
-	if isProtected, err := currentSnap.IsProtected(); err != nil {
-		if !errors.Is(err, librbd.ErrNotFound) {
-			return fmt.Errorf("failed to check if snapshot %s is protected: %w", ImageSnapshotVersion, err)
-		}
-	} else if isProtected {
-		log.V(2).Info("Snapshot already exists and is protected, skipping creation and protection.", "snapshotName", ImageSnapshotVersion)
+	if isSnapshotExist, err := snapshotExists(log, ioCtx, rbdImageID, ImageSnapshotVersion); err == nil && isSnapshotExist {
 		return nil
 	}
 

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -266,7 +266,7 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
 		snapshot.Status.State = providerapi.SnapshotStateFailed
 		if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
-			return errors.Join(fmt.Errorf("failed to update snapshot: %w", updateErr))
+			return errors.Join(err, fmt.Errorf("failed to update snapshot: %w", updateErr))
 		}
 		return fmt.Errorf("failed to check snapshot existence: %w", err)
 	}

--- a/internal/controllers/snapshot_controller.go
+++ b/internal/controllers/snapshot_controller.go
@@ -262,16 +262,23 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 	}
 
 	log.V(2).Info("Check if rbd snapshot exists")
-	isSnapshotExist, err := snapshotExists(log, ioCtx, rbdID, snapshotID)
+	isSnapshotExist, isSnapshotProtected, err := snapshotExistsAndProtected(log, ioCtx, rbdID, snapshotID)
 	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
 		snapshot.Status.State = providerapi.SnapshotStateFailed
-		if _, err = r.store.Update(ctx, snapshot); err != nil {
-			return fmt.Errorf("failed to update snapshot: %w", err)
+		if _, updateErr := r.store.Update(ctx, snapshot); updateErr != nil {
+			return errors.Join(fmt.Errorf("failed to update snapshot: %w", updateErr))
 		}
 		return fmt.Errorf("failed to check snapshot existence: %w", err)
 	}
 
 	if isSnapshotExist {
+		if !isSnapshotProtected {
+			// Snapshot exists but not protected - just protect it
+			if err := protectSnapshot(log, ioCtx, rbdID, snapshotID); err != nil {
+				return fmt.Errorf("failed to protect snapshot: %w", err)
+			}
+		}
+
 		// SnapshotStatePopulated is no longer actively used. It has been replaced by SnapshotStateReady.
 		// This block will transition any snapshots that are in SnapshotStatePopulated to SnapshotStateReady.
 		if snapshot.Status.State == providerapi.SnapshotStatePopulated {
@@ -294,7 +301,7 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 			err = r.reconcileIroncoreImageSnapshot(ctx, log, ioCtx, snapshot)
 		case snapshot.Source.VolumeImageID != "":
 			if snapshot.Status.State == providerapi.SnapshotStateFailed {
-				log.V(1).Info("Skipping snapshot creation", "reason", "Snapshot is failed after creation due to missing rbd snapshot")
+				log.V(1).Info("Skipping snapshot creation: source volume RBD image snapshot was deleted, snapshot cannot be recreated")
 				return nil
 			}
 			err = r.reconcileVolumeImageSnapshot(ctx, log, ioCtx, snapshot)


### PR DESCRIPTION
# Proposed Changes

- Before cloning image, check if rbd image of volume source exists. If rbd image doesn't exist, then mark the snapshot state as `Failed`
- Check if rbd snapshot exists during snapshot recociliation. And before checking snapshot state, check for rbd image existence also.
- Create rbd image for ironcore image only when it's not present.
- Check rbd snapshot existence before populating image.
- Improve logs.

Fixes #842 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger existence and protection checks for snapshots and images to avoid duplicate work and failed operations
  * Prevents cloning/resizing when referenced snapshots are missing or unprotected; updates snapshot state to Failed with clearer, contextual error messages
  * Ensures already-protected snapshots are handled safely and protected as needed before use

* **Refactor**
  * Snapshot preparation and image workflows now operate on direct image handles for safer resource management and clearer control flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->