### PR TITLE
Fix event drops by buffering the omap watch channel

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -67,7 +67,7 @@ jobs:
           version: latest
           endpoint: builders
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ok-to-image')
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -78,8 +78,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64 ,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ok-to-image') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: ${{ matrix.image.target }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -67,7 +67,7 @@ jobs:
           version: latest
           endpoint: builders
       - name: Login to GHCR
-        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ok-to-image')
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -78,8 +78,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ok-to-image') }}
+          platforms: linux/amd64 ,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: ${{ matrix.image.target }}

--- a/cmd/volumeprovider/app/app.go
+++ b/cmd/volumeprovider/app/app.go
@@ -208,7 +208,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	setupLog.Info("Configuring image store", "OmapName", omap.NameVolumes)
-	imageStore, err := omap.New(conn, opts.Ceph.Pool, omap.Options[*providerapi.Image]{
+	imageStore, err := omap.New(log.WithName("image-events"), conn, opts.Ceph.Pool, omap.Options[*providerapi.Image]{
 		OmapName:       omap.NameVolumes,
 		NewFunc:        func() *providerapi.Image { return &providerapi.Image{} },
 		CreateStrategy: strategy.ImageStrategy,
@@ -227,7 +227,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	setupLog.Info("Configuring snapshot store", "OmapName", omap.NameSnapshots)
-	snapshotStore, err := omap.New(conn, opts.Ceph.Pool, omap.Options[*providerapi.Snapshot]{
+	snapshotStore, err := omap.New(log.WithName("snapshot-events"), conn, opts.Ceph.Pool, omap.Options[*providerapi.Snapshot]{
 		OmapName:       omap.NameSnapshots,
 		NewFunc:        func() *providerapi.Snapshot { return &providerapi.Snapshot{} },
 		CreateStrategy: strategy.SnapshotStrategy,

--- a/internal/omap/omap.go
+++ b/internal/omap/omap.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ceph/go-ceph/rados"
+	"github.com/go-logr/logr"
 	utilssync "github.com/ironcore-dev/ceph-provider/internal/sync"
 	"github.com/ironcore-dev/ceph-provider/internal/utils"
 	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
@@ -31,7 +32,7 @@ type Options[E apiutils.Object] struct {
 	CreateStrategy CreateStrategy[E]
 }
 
-func New[E apiutils.Object](conn *rados.Conn, pool string, opts Options[E]) (*Store[E], error) {
+func New[E apiutils.Object](log logr.Logger, conn *rados.Conn, pool string, opts Options[E]) (*Store[E], error) {
 	if conn == nil {
 		return nil, fmt.Errorf("must specify conn")
 	}
@@ -51,6 +52,8 @@ func New[E apiutils.Object](conn *rados.Conn, pool string, opts Options[E]) (*St
 	return &Store[E]{
 		idMu: utilssync.NewMutexMap[string](),
 
+		log: log,
+
 		conn:     conn,
 		pool:     pool,
 		omapName: opts.OmapName,
@@ -64,6 +67,8 @@ func New[E apiutils.Object](conn *rados.Conn, pool string, opts Options[E]) (*St
 
 type Store[E apiutils.Object] struct {
 	idMu *utilssync.MutexMap[string]
+
+	log logr.Logger
 
 	conn     *rados.Conn
 	pool     string
@@ -81,6 +86,7 @@ func (s *Store[E]) enqueue(evt store.WatchEvent[E]) {
 		select {
 		case handler.events <- evt:
 		default:
+			s.log.V(1).Info("Dropping watch event, due to full channel", "event", evt)
 		}
 	}
 }

--- a/internal/omap/omap.go
+++ b/internal/omap/omap.go
@@ -87,7 +87,7 @@ func (s *Store[E]) enqueue(evt store.WatchEvent[E]) {
 		case handler.events <- evt:
 		default:
 			// TODO: switch to `ctx` to backpressure, if channel size is not enough
-			s.log.V(1).Info("Dropping watch event, due to full channel", "event", evt)
+			s.log.Info("Dropping watch event, due to full channel", "event", evt)
 		}
 	}
 }

--- a/internal/omap/omap.go
+++ b/internal/omap/omap.go
@@ -86,6 +86,7 @@ func (s *Store[E]) enqueue(evt store.WatchEvent[E]) {
 		select {
 		case handler.events <- evt:
 		default:
+			// TODO: switch to `ctx` to backpressure, if channel size is not enough
 			s.log.V(1).Info("Dropping watch event, due to full channel", "event", evt)
 		}
 	}
@@ -288,7 +289,7 @@ func (s *Store[E]) Watch(ctx context.Context) (store.Watch[E], error) {
 
 	w := &watch[E]{
 		store:  s,
-		events: make(chan store.WatchEvent[E]),
+		events: make(chan store.WatchEvent[E], 1024),
 	}
 
 	s.watches.Insert(w)


### PR DESCRIPTION
# Proposed Changes

  - Increase the omap store watch channel from unbuffered (size 0) to a buffered channel of 1024, preventing silent event drops under burst load
  - Add a warning log when the channel is full and an event is dropped, making the failure mode visible

Fixes #885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images can now be built and published from pull requests when the appropriate label is present.

* **Bug Fixes**
  * Improved event handling for storage-backed image and snapshot updates, reducing dropped notifications under load.
  * Added clearer logging around event delivery issues to help surface missed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->