### PR TITLE
Fetch omap values by keys instead of fetching all values

### DIFF
--- a/internal/omap/omap.go
+++ b/internal/omap/omap.go
@@ -99,14 +99,14 @@ func getOmapValuesByKeys(ioCtx *rados.IOContext, omapName string, keys []string)
 	step := op.GetOmapValuesByKeys(keys)
 
 	if err := op.Operate(ioCtx, omapName, rados.OperationNoFlag); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ceph read operation failed: %w", err)
 	}
 
 	result := make(map[string][]byte, len(keys))
 	for {
 		kv, err := step.Next()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to iterate over ceph read results: %w", err)
 		}
 		if kv == nil {
 			return result, nil

--- a/internal/omap/omap.go
+++ b/internal/omap/omap.go
@@ -92,18 +92,27 @@ func (s *Store[E]) watchHandlers() []*watch[E] {
 	return s.watches.UnsortedList()
 }
 
-func (s *Store[E]) getSingleOmapValue(ioCtx *rados.IOContext, omapName, key string) ([]byte, error) {
-	omap, err := ioCtx.GetAllOmapValues(omapName, "", key, 10)
-	if err != nil {
+func getOmapValuesByKeys(ioCtx *rados.IOContext, omapName string, keys []string) (map[string][]byte, error) {
+	op := rados.CreateReadOp()
+	defer op.Release()
+
+	step := op.GetOmapValuesByKeys(keys)
+
+	if err := op.Operate(ioCtx, omapName, rados.OperationNoFlag); err != nil {
 		return nil, err
 	}
 
-	value, ok := omap[key]
-	if !ok {
-		return nil, rados.ErrNotFound
+	result := make(map[string][]byte, len(keys))
+	for {
+		kv, err := step.Next()
+		if err != nil {
+			return nil, err
+		}
+		if kv == nil {
+			return result, nil
+		}
+		result[kv.Key] = kv.Value
 	}
-
-	return value, nil
 }
 
 func (s *Store[E]) deleteOmapValue(ioCtx *rados.IOContext, omapName, key string) error {
@@ -332,17 +341,19 @@ func (s *Store[E]) set(ioCtx *rados.IOContext, obj E) (E, error) {
 }
 
 func (s *Store[E]) get(ioCtx *rados.IOContext, id string) (E, error) {
-	data, err := s.getSingleOmapValue(ioCtx, s.omapName, id)
+	data, err := getOmapValuesByKeys(ioCtx, s.omapName, []string{id})
 	if err != nil {
 		if !errors.Is(err, rados.ErrNotFound) {
 			return utils.Zero[E](), fmt.Errorf("failed to fetch omap value: %w", err)
 		}
-
+		return utils.Zero[E](), fmt.Errorf("object with id %q: %w", id, store.ErrNotFound)
+	}
+	if data[id] == nil {
 		return utils.Zero[E](), fmt.Errorf("object with id %q: %w", id, store.ErrNotFound)
 	}
 
 	obj := s.newFunc()
-	if err := json.Unmarshal(data, obj); err != nil {
+	if err := json.Unmarshal(data[id], obj); err != nil {
 		return utils.Zero[E](), fmt.Errorf("failed to unmarshal object: %w", err)
 	}
 


### PR DESCRIPTION
# Proposed Changes

- Remove `getSingleOmapValue` method from omap store
- Add `getOmapValuesByKeys` method to omap store

`getSingleOmapValue` was using [`GetAllOmapValues`](https://pkg.go.dev/github.com/ceph/go-ceph@v0.40.0/rados#IOContext.GetAllOmapValues) under the hood, (see #887 for why this is bad). `getOmapValuesByKeys` uses [`GetOmapValuesByKeys`](https://pkg.go.dev/github.com/ceph/go-ceph@v0.40.0/rados#ReadOp.GetOmapValuesByKeys) instead, which should perform better and allow better for future development (e.g. indexing).

Fixes #887


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing records so “not found” outcomes are more consistent across lookup paths.
  * Reduced inconsistencies in how lookup errors are reported.
  * Updated record retrieval to use a more efficient bulk-read strategy for key lookups, enhancing performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->