### PR TITLE
Make omap iterator size configurable

### DIFF
--- a/cmd/volumeprovider/app/app.go
+++ b/cmd/volumeprovider/app/app.go
@@ -59,7 +59,8 @@ type CephOptions struct {
 
 	VolumeEventStoreOptions eventrecorder.EventStoreOptions
 
-	WorkerSize int
+	WorkerSize       int
+	OmapIteratorSize int64
 }
 
 func (o *Options) Defaults() {
@@ -68,6 +69,7 @@ func (o *Options) Defaults() {
 	o.Ceph.BurstDurationInSeconds = 15
 	o.Ceph.PopulatorBufferSize = 5 * 1024 * 1024
 	o.Ceph.WorkerSize = 15
+	o.Ceph.OmapIteratorSize = 1000
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
@@ -93,6 +95,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.Ceph.VolumeEventStoreOptions.ResyncInterval, "volume-event-resync-interval", 1*time.Minute, "Interval for resynchronizing the volume events.")
 
 	fs.IntVar(&o.Ceph.WorkerSize, "worker-size", o.Ceph.WorkerSize, "Defines the factor to calculate the burst limits.")
+	fs.Int64Var(&o.Ceph.OmapIteratorSize, "omap-iterator-size", o.Ceph.OmapIteratorSize, "Batch size used when iterating omap values during List.")
 }
 
 func (o *Options) MarkFlagsRequired(cmd *cobra.Command) {
@@ -212,6 +215,7 @@ func Run(ctx context.Context, opts Options) error {
 		OmapName:       omap.NameVolumes,
 		NewFunc:        func() *providerapi.Image { return &providerapi.Image{} },
 		CreateStrategy: strategy.ImageStrategy,
+		IteratorSize:   opts.Ceph.OmapIteratorSize,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize image store: %w", err)
@@ -231,6 +235,7 @@ func Run(ctx context.Context, opts Options) error {
 		OmapName:       omap.NameSnapshots,
 		NewFunc:        func() *providerapi.Snapshot { return &providerapi.Snapshot{} },
 		CreateStrategy: strategy.SnapshotStrategy,
+		IteratorSize:   opts.Ceph.OmapIteratorSize,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize snapshot store: %w", err)

--- a/internal/omap/omap.go
+++ b/internal/omap/omap.go
@@ -30,6 +30,7 @@ type Options[E apiutils.Object] struct {
 	OmapName       string
 	NewFunc        func() E
 	CreateStrategy CreateStrategy[E]
+	IteratorSize   int64
 }
 
 func New[E apiutils.Object](log logr.Logger, conn *rados.Conn, pool string, opts Options[E]) (*Store[E], error) {
@@ -49,6 +50,10 @@ func New[E apiutils.Object](log logr.Logger, conn *rados.Conn, pool string, opts
 		return nil, fmt.Errorf("must specify opts.NewFunc")
 	}
 
+	if opts.IteratorSize <= 0 {
+		return nil, fmt.Errorf("must specify opts.IteratorSize (must be > 0)")
+	}
+
 	return &Store[E]{
 		idMu: utilssync.NewMutexMap[string](),
 
@@ -57,6 +62,8 @@ func New[E apiutils.Object](log logr.Logger, conn *rados.Conn, pool string, opts
 		conn:     conn,
 		pool:     pool,
 		omapName: opts.OmapName,
+
+		iteratorSize: opts.IteratorSize,
 
 		watches: sets.New[*watch[E]](),
 
@@ -70,9 +77,10 @@ type Store[E apiutils.Object] struct {
 
 	log logr.Logger
 
-	conn     *rados.Conn
-	pool     string
-	omapName string
+	conn         *rados.Conn
+	pool         string
+	omapName     string
+	iteratorSize int64
 
 	newFunc        func() E
 	createStrategy CreateStrategy[E]
@@ -313,7 +321,7 @@ func (s *Store[E]) List(ctx context.Context) ([]E, error) {
 	}
 	defer ioCtx.Destroy()
 
-	omap, err := ioCtx.GetAllOmapValues(s.omapName, "", "", 10)
+	omap, err := ioCtx.GetAllOmapValues(s.omapName, "", "", s.iteratorSize)
 	if err != nil {
 		if errors.Is(err, rados.ErrNotFound) {
 			return nil, nil

--- a/tests/integration/integration_suite_test.go
+++ b/tests/integration/integration_suite_test.go
@@ -103,7 +103,8 @@ var _ = BeforeSuite(func() {
 				TTL:            eventTTL,
 				ResyncInterval: resyncInterval,
 			},
-			WorkerSize: 15,
+			WorkerSize:       15,
+			OmapIteratorSize: 1000,
 		},
 	}
 


### PR DESCRIPTION
# Proposed Changes

- omap store: Make iterator size configurable via Options
- volumeprovider: Add `--omap-iterator-size` flag
- volumeprovider: Set default iterator size to 1000

These changes should improve the performance of omap list requests. Before this
change, list requests used an iteratorSize of 10, resulting in a lot of
requests to omap. Increasing the iteratorSize will result in less requests to
omap and therefore less waiting on I/O.

In addition to the new default this PR also adds a new flag to make the
iterator size configurable for users, allowing for better fine tuning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable OMAP iterator size option to control OMAP iteration batch sizing for both image and snapshot processing.
  * Introduced the `--omap-iterator-size` command-line flag to set this value.
* **Bug Fixes**
  * Validates the configured iterator size is greater than zero before initializing OMAP storage.
* **Tests**
  * Updated the integration test configuration to explicitly set an iterator size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->