### PR TITLE
Remove `paths-ignore` filters from required workflows

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -3,8 +3,6 @@ name: Run integration tests
 on:
   pull_request:
     types: [labeled, synchronize, reopened]
-    paths-ignore:
-      - 'docs/**'
 
 jobs:
   integration-tests:

--- a/.github/workflows/kustomize-validation.yml
+++ b/.github/workflows/kustomize-validation.yml
@@ -3,9 +3,6 @@ name: Kustomize Validation
 on:
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 
 jobs:
   kustomize-validation:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,7 @@ name: Lint Golang Codebase
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -9,13 +9,7 @@ on:
       - main
     tags:
       - v*
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
     types: [labeled, unlabeled, opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,6 @@ name: Pull Request Code test
 on:
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 
 jobs:
   checks:


### PR DESCRIPTION
# Proposed Changes

- Remove path filters from required workflows. The filters prevent PRs from
  merging if they do not match the filter.

