### PR TITLE
Add stale bot to close inactive issues and PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stale for 5 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stale for 10 days with no activity.'
+          days-before-issue-stale: 30
+          days-before-pr-stale: 45
+          days-before-issue-close: 5
+          days-before-pr-close: 10


### PR DESCRIPTION
# Proposed Changes

- Add stale bot to close inactive issues and PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated management of inactive issues and pull requests.
  * Inactive issues are marked stale after 30 days and closed 5 days later if there is no activity.
  * Inactive pull requests are marked stale after 45 days and closed 10 days later if they remain inactive.
  * Added clear notifications explaining stale and closure status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->