### PR TITLE
Implement indexing for `omap.Store`

### DIFF
--- a/api/image.go
+++ b/api/image.go
@@ -7,6 +7,17 @@ import (
 	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
 )
 
+const (
+	ImageSpecSnapshotRefField = "spec.snapshotRef"
+)
+
+func SetupImageSpecSnapshotRefFieldIndexer(img *Image) string {
+	if img.Spec.SnapshotRef != nil {
+		return *img.Spec.SnapshotRef
+	}
+	return ""
+}
+
 type Image struct {
 	apiutils.Metadata `json:"metadata,omitempty"`
 

--- a/cmd/volumeprovider/app/app.go
+++ b/cmd/volumeprovider/app/app.go
@@ -24,6 +24,7 @@ import (
 	iriv1alpha1 "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 	"github.com/ironcore-dev/provider-utils/eventutils/event"
 	eventrecorder "github.com/ironcore-dev/provider-utils/eventutils/recorder"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
@@ -216,6 +217,9 @@ func Run(ctx context.Context, opts Options) error {
 		NewFunc:        func() *providerapi.Image { return &providerapi.Image{} },
 		CreateStrategy: strategy.ImageStrategy,
 		IteratorSize:   opts.Ceph.OmapIteratorSize,
+		FieldIndexers: map[string]store.IndexerFunc[*providerapi.Image]{
+			providerapi.ImageSpecSnapshotRefField: providerapi.SetupImageSpecSnapshotRefFieldIndexer,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize image store: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.1 // indirect
-	github.com/prometheus/procfs v0.21.0 // indirect
+	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -180,3 +180,5 @@ exclude (
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/client-go v12.0.0+incompatible
 )
+
+replace github.com/ironcore-dev/provider-utils => github.com/gonzolino/provider-utils v0.0.0-20260717132014-d03710ca0653

--- a/go.sum
+++ b/go.sum
@@ -415,6 +415,8 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gonzolino/provider-utils v0.0.0-20260717132014-d03710ca0653 h1:kW/kyGJZSi4DfEupAn8ckUPkeU84PSUbDYamO3at2Tw=
+github.com/gonzolino/provider-utils v0.0.0-20260717132014-d03710ca0653/go.mod h1:iJRqG5HczAtgYVXEob25/AuNV7NgyqXlPtYEfOTwTRs=
 github.com/google/addlicense v1.2.0 h1:W+DP4A639JGkcwBGMDvjSurZHvaq2FN0pP7se9czsKA=
 github.com/google/addlicense v1.2.0/go.mod h1:Sm/DHu7Jk+T5miFHHehdIjbi4M5+dJDRS3Cq0rncIxA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -574,8 +576,6 @@ github.com/ironcore-dev/ironcore v0.4.3 h1:G3TmR4r3LtbmakMkxDa2pPlLCmxAfGVBEdy+Q
 github.com/ironcore-dev/ironcore v0.4.3/go.mod h1:vFpdcyC4QD7o3j01lpux12NET6vNPDAq3hzrFOY9QOc=
 github.com/ironcore-dev/ironcore-image v0.5.1-0.20260701105042-7ab1ed925593 h1:ZleC2YP7AdLcymcaw82KpXShe09/tScazn7x+SuktTc=
 github.com/ironcore-dev/ironcore-image v0.5.1-0.20260701105042-7ab1ed925593/go.mod h1:+qAuB3n8SQN0XmYwNPa1UkjDIZAQhpGxfpiAXcUL2dM=
-github.com/ironcore-dev/provider-utils v0.0.0-20260706064412-a5700fe459b6 h1:pdg6esPunmxzig5Vh9fU3PELRVhkihsOMVLeRDRgP1U=
-github.com/ironcore-dev/provider-utils v0.0.0-20260706064412-a5700fe459b6/go.mod h1:8RVoVQCuxRxWtSXiIKB70U0SHrxFuGXNbvQoibk5jY8=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -788,8 +788,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/prometheus/procfs v0.21.0 h1:Qh/e6TlBjZf+XLLqNCqFGmCU6Kj/2Bu7kj3oAc0UnXc=
-github.com/prometheus/procfs v0.21.0/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
+github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
+github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/internal/controllers/image_controller.go
+++ b/internal/controllers/image_controller.go
@@ -152,7 +152,7 @@ func (r *ImageReconciler) Start(ctx context.Context) error {
 			return
 		}
 
-		imageList, err := r.images.List(ctx)
+		imageList, err := r.images.List(ctx, store.MatchingFields{providerapi.ImageSpecSnapshotRefField: evt.Object.ID})
 		if err != nil {
 			log.Error(err, "failed to list images")
 			return

--- a/internal/omap/omap.go
+++ b/internal/omap/omap.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ironcore-dev/provider-utils/storeutils/store"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -62,7 +63,7 @@ func New[E apiutils.Object](log logr.Logger, conn *rados.Conn, pool string, opts
 		indexers[k] = v
 	}
 
-	return &Store[E]{
+	s := &Store[E]{
 		idMu: utilssync.NewMutexMap[string](),
 
 		log: log,
@@ -78,8 +79,30 @@ func New[E apiutils.Object](log logr.Logger, conn *rados.Conn, pool string, opts
 		newFunc:        opts.NewFunc,
 		createStrategy: opts.CreateStrategy,
 
-		indexers: indexers,
-	}, nil
+		indexers:   indexers,
+		labelIndex: make(map[string]map[string]sets.Set[string]),
+		fieldIndex: make(map[string]map[string]sets.Set[string]),
+	}
+
+	ioCtx, err := conn.OpenIOContext(pool)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get io context for index warmup: %w", err)
+	}
+	defer ioCtx.Destroy()
+
+	omap, err := ioCtx.GetAllOmapValues(opts.OmapName, "", "", 10)
+	if err != nil && !errors.Is(err, rados.ErrNotFound) {
+		return nil, fmt.Errorf("error warming up index: %w", err)
+	}
+	for _, v := range omap {
+		obj := opts.NewFunc()
+		if err := json.Unmarshal(v, obj); err != nil {
+			return nil, fmt.Errorf("error warming up index: %w", err)
+		}
+		s.addToIndex(obj)
+	}
+
+	return s, nil
 }
 
 type Store[E apiutils.Object] struct {
@@ -99,6 +122,10 @@ type Store[E apiutils.Object] struct {
 	watches   sets.Set[*watch[E]]
 
 	indexers map[string]store.IndexerFunc[E]
+
+	indexMu    sync.RWMutex
+	labelIndex map[string]map[string]sets.Set[string]
+	fieldIndex map[string]map[string]sets.Set[string]
 }
 
 func (s *Store[E]) enqueue(evt store.WatchEvent[E]) {
@@ -117,6 +144,121 @@ func (s *Store[E]) watchHandlers() []*watch[E] {
 	defer s.watchesMu.RUnlock()
 
 	return s.watches.UnsortedList()
+}
+
+func (s *Store[E]) addToIndex(obj E) {
+	s.indexMu.Lock()
+	defer s.indexMu.Unlock()
+
+	id := obj.GetID()
+	for k, v := range obj.GetLabels() {
+		if s.labelIndex[k] == nil {
+			s.labelIndex[k] = make(map[string]sets.Set[string])
+		}
+		if s.labelIndex[k][v] == nil {
+			s.labelIndex[k][v] = sets.New[string]()
+		}
+		s.labelIndex[k][v].Insert(id)
+	}
+	for field, fn := range s.indexers {
+		v := fn(obj)
+		if s.fieldIndex[field] == nil {
+			s.fieldIndex[field] = make(map[string]sets.Set[string])
+		}
+		if s.fieldIndex[field][v] == nil {
+			s.fieldIndex[field][v] = sets.New[string]()
+		}
+		s.fieldIndex[field][v].Insert(id)
+	}
+}
+
+func (s *Store[E]) removeFromIndex(obj E) {
+	s.indexMu.Lock()
+	defer s.indexMu.Unlock()
+
+	id := obj.GetID()
+	for k, v := range obj.GetLabels() {
+		if m := s.labelIndex[k]; m != nil {
+			m[v].Delete(id)
+		}
+	}
+	for field, fn := range s.indexers {
+		v := fn(obj)
+		if m := s.fieldIndex[field]; m != nil {
+			m[v].Delete(id)
+		}
+	}
+}
+
+// resolveCandidateIDs returns the set of IDs matching all positive index-backed
+// requirements. Returns nil when no filters are present (full scan needed).
+// Negative label requirements (NotIn, DoesNotExist) are skipped here and
+// applied as a post-filter in List.
+func (s *Store[E]) resolveCandidateIDs(opts *store.ListOptions) sets.Set[string] {
+	s.indexMu.RLock()
+	defer s.indexMu.RUnlock()
+
+	var result sets.Set[string]
+	hasFilter := false
+
+	if opts.LabelSelector != nil {
+		reqs, selectable := opts.LabelSelector.Requirements()
+		if !selectable {
+			return sets.New[string]()
+		}
+		for _, req := range reqs {
+			switch req.Operator() {
+			case selection.Equals, selection.DoubleEquals, selection.In:
+				hasFilter = true
+				ids := sets.New[string]()
+				if m := s.labelIndex[req.Key()]; m != nil {
+					for v := range req.Values() {
+						if s := m[v]; s != nil {
+							ids = ids.Union(s)
+						}
+					}
+				}
+				result = indexIntersect(result, ids)
+			case selection.Exists:
+				hasFilter = true
+				ids := sets.New[string]()
+				if m := s.labelIndex[req.Key()]; m != nil {
+					for _, s := range m {
+						ids = ids.Union(s)
+					}
+				}
+				result = indexIntersect(result, ids)
+			}
+		}
+	}
+
+	if opts.FieldSelector != nil {
+		for _, req := range opts.FieldSelector.Requirements() {
+			hasFilter = true
+			ids := sets.New[string]()
+			if m := s.fieldIndex[req.Field]; m != nil {
+				if s := m[req.Value]; s != nil {
+					ids = s.Union(sets.New[string]())
+				}
+			}
+			result = indexIntersect(result, ids)
+		}
+	}
+
+	if !hasFilter {
+		return nil
+	}
+	if result == nil {
+		return sets.New[string]()
+	}
+	return result
+}
+
+func indexIntersect(a, b sets.Set[string]) sets.Set[string] {
+	if a == nil {
+		return b.Union(sets.New[string]())
+	}
+	return a.Intersection(b)
 }
 
 func getOmapValuesByKeys(ioCtx *rados.IOContext, omapName string, keys []string) (map[string][]byte, error) {
@@ -191,6 +333,8 @@ func (s *Store[E]) Create(ctx context.Context, obj E) (E, error) {
 		return utils.Zero[E](), err
 	}
 
+	s.addToIndex(obj)
+
 	s.enqueue(store.WatchEvent[E]{
 		Type:   store.WatchEventTypeCreated,
 		Object: obj,
@@ -215,7 +359,7 @@ func (s *Store[E]) Delete(ctx context.Context, id string) error {
 	}
 
 	if len(obj.GetFinalizers()) == 0 {
-		return s.delete(ioCtx, id)
+		return s.delete(ioCtx, obj)
 	}
 
 	if obj.GetDeletedAt() != nil {
@@ -238,8 +382,10 @@ func (s *Store[E]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (s *Store[E]) delete(ioCtx *rados.IOContext, id string) error {
-	if err := s.deleteOmapValue(ioCtx, s.omapName, id); err != nil {
+func (s *Store[E]) delete(ioCtx *rados.IOContext, obj E) error {
+	s.removeFromIndex(obj)
+
+	if err := s.deleteOmapValue(ioCtx, s.omapName, obj.GetID()); err != nil {
 		return fmt.Errorf("failed to delete object from omap: %w", err)
 	}
 	return nil
@@ -271,7 +417,7 @@ func (s *Store[E]) Update(ctx context.Context, obj E) (E, error) {
 	}
 
 	if obj.GetDeletedAt() != nil && len(obj.GetFinalizers()) == 0 {
-		if err := s.delete(ioCtx, obj.GetID()); err != nil {
+		if err := s.delete(ioCtx, obj); err != nil {
 			return utils.Zero[E](), fmt.Errorf("failed to delete object metadata: %w", err)
 		}
 		return obj, nil
@@ -286,6 +432,9 @@ func (s *Store[E]) Update(ctx context.Context, obj E) (E, error) {
 	if err != nil {
 		return utils.Zero[E](), err
 	}
+
+	s.removeFromIndex(oldObj)
+	s.addToIndex(obj)
 
 	s.enqueue(store.WatchEvent[E]{
 		Type:   store.WatchEventTypeUpdated,
@@ -345,6 +494,30 @@ func (s *Store[E]) List(ctx context.Context, opts ...store.ListOption) ([]E, err
 		return nil, fmt.Errorf("unable to get io context: %w", err)
 	}
 	defer ioCtx.Destroy()
+
+	candidateIDs := s.resolveCandidateIDs(listOpts)
+
+	if candidateIDs != nil {
+		if candidateIDs.Len() == 0 {
+			return nil, nil
+		}
+		omap, err := getOmapValuesByKeys(ioCtx, s.omapName, candidateIDs.UnsortedList())
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch objects by keys: %w", err)
+		}
+		var objs []E
+		for _, v := range omap {
+			obj := s.newFunc()
+			if err := json.Unmarshal(v, &obj); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal object: %w", err)
+			}
+			if listOpts.LabelSelector != nil && !listOpts.LabelSelector.Matches(labels.Set(obj.GetLabels())) {
+				continue
+			}
+			objs = append(objs, obj)
+		}
+		return objs, nil
+	}
 
 	omap, err := ioCtx.GetAllOmapValues(s.omapName, "", "", s.iteratorSize)
 	if err != nil {

--- a/internal/omap/omap.go
+++ b/internal/omap/omap.go
@@ -17,6 +17,8 @@ import (
 	"github.com/ironcore-dev/ceph-provider/internal/utils"
 	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
 	"github.com/ironcore-dev/provider-utils/storeutils/store"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -31,6 +33,7 @@ type Options[E apiutils.Object] struct {
 	NewFunc        func() E
 	CreateStrategy CreateStrategy[E]
 	IteratorSize   int64
+	FieldIndexers  map[string]store.IndexerFunc[E]
 }
 
 func New[E apiutils.Object](log logr.Logger, conn *rados.Conn, pool string, opts Options[E]) (*Store[E], error) {
@@ -54,6 +57,11 @@ func New[E apiutils.Object](log logr.Logger, conn *rados.Conn, pool string, opts
 		return nil, fmt.Errorf("must specify opts.IteratorSize (must be > 0)")
 	}
 
+	indexers := make(map[string]store.IndexerFunc[E], len(opts.FieldIndexers))
+	for k, v := range opts.FieldIndexers {
+		indexers[k] = v
+	}
+
 	return &Store[E]{
 		idMu: utilssync.NewMutexMap[string](),
 
@@ -69,6 +77,8 @@ func New[E apiutils.Object](log logr.Logger, conn *rados.Conn, pool string, opts
 
 		newFunc:        opts.NewFunc,
 		createStrategy: opts.CreateStrategy,
+
+		indexers: indexers,
 	}, nil
 }
 
@@ -87,6 +97,8 @@ type Store[E apiutils.Object] struct {
 
 	watchesMu sync.RWMutex
 	watches   sets.Set[*watch[E]]
+
+	indexers map[string]store.IndexerFunc[E]
 }
 
 func (s *Store[E]) enqueue(evt store.WatchEvent[E]) {
@@ -314,7 +326,20 @@ func (s *Store[E]) Watch(ctx context.Context) (store.Watch[E], error) {
 	return w, nil
 }
 
-func (s *Store[E]) List(ctx context.Context) ([]E, error) {
+func (s *Store[E]) List(ctx context.Context, opts ...store.ListOption) ([]E, error) {
+	listOpts := &store.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(listOpts)
+	}
+
+	if listOpts.FieldSelector != nil {
+		for _, req := range listOpts.FieldSelector.Requirements() {
+			if _, ok := s.indexers[req.Field]; !ok {
+				return nil, fmt.Errorf("field selector references unindexed field %q", req.Field)
+			}
+		}
+	}
+
 	ioCtx, err := s.conn.OpenIOContext(s.pool)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get io context: %w", err)
@@ -334,6 +359,20 @@ func (s *Store[E]) List(ctx context.Context) ([]E, error) {
 		obj := s.newFunc()
 		if err := json.Unmarshal(v, &obj); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal object: %w", err)
+		}
+
+		if listOpts.LabelSelector != nil && !listOpts.LabelSelector.Matches(labels.Set(obj.GetLabels())) {
+			continue
+		}
+
+		if listOpts.FieldSelector != nil {
+			merged := fields.Set{}
+			for field, fn := range s.indexers {
+				merged[field] = fn(obj)
+			}
+			if !listOpts.FieldSelector.Matches(merged) {
+				continue
+			}
 		}
 
 		objs = append(objs, obj)

--- a/internal/volumeserver/volume_list.go
+++ b/internal/volumeserver/volume_list.go
@@ -51,17 +51,13 @@ func (s *Server) filterVolumes(volumes []*iri.Volume, filter *iri.VolumeFilter) 
 }
 
 func (s *Server) listVolumes(ctx context.Context) ([]*iri.Volume, error) {
-	cephImages, err := s.imageStore.List(ctx)
+	cephImages, err := s.imageStore.List(ctx, store.MatchingLabels{api.ManagerLabel: api.VolumeManager})
 	if err != nil {
 		return nil, fmt.Errorf("error listing volumes: %w", err)
 	}
 
 	var res []*iri.Volume
 	for _, cephImage := range cephImages {
-		if !api.IsObjectManagedBy(cephImage, api.VolumeManager) {
-			continue
-		}
-
 		iriVolume, err := s.convertImageToIriVolume(cephImage)
 		if err != nil {
 			return nil, err

--- a/internal/volumeserver/volumesnapshot_list.go
+++ b/internal/volumeserver/volumesnapshot_list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ironcore-dev/ceph-provider/api"
 	"github.com/ironcore-dev/ceph-provider/internal/utils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -49,17 +50,13 @@ func (s *Server) filterSnapshot(snapshots []*iri.VolumeSnapshot, filter *iri.Vol
 }
 
 func (s *Server) listSnapshots(ctx context.Context) ([]*iri.VolumeSnapshot, error) {
-	cephSnapshots, err := s.snapshotStore.List(ctx)
+	cephSnapshots, err := s.snapshotStore.List(ctx, store.MatchingLabels{api.ManagerLabel: api.VolumeManager})
 	if err != nil {
 		return nil, fmt.Errorf("error listing snapshots: %w", err)
 	}
 
 	var res []*iri.VolumeSnapshot
 	for _, cephSnapshot := range cephSnapshots {
-		if !api.IsObjectManagedBy(cephSnapshot, api.VolumeManager) {
-			continue
-		}
-
 		iriSnapshot, err := s.convertSnapshotToIriVolumeSnapshot(cephSnapshot)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Proposed Changes
Add indexing for labels and indexed fields (specified via `FieldIndexers` when initializing a `omap.Store`)

This is an optimization based on https://github.com/ironcore-dev/provider-utils/pull/56 and #883. https://github.com/ironcore-dev/provider-utils/pull/56 allows filtering `List` queries by providing `ListOptions`. However, even when filtering like this the store will still fetch all object from store and apply filtering later. This PR optimizes this by adding indexes for labels and fields so the store only needs to fetch the objects from the index.

**Note:** This is an early draft to show how indexing could be implemented after https://github.com/ironcore-dev/provider-utils/pull/56 and #883 has been merged. It is not tested properly yet.
