### PR TITLE
Fix VolumeClass quantity calculation in IRI Status method

### DIFF
--- a/internal/ceph/commands.go
+++ b/internal/ceph/commands.go
@@ -48,7 +48,7 @@ type Pool struct {
 }
 
 type PoolStats struct {
-	Stored      int     `json:"stored"`
+	Stored      int64   `json:"stored"`
 	Objects     int     `json:"objects"`
 	KbUsed      int     `json:"kb_used"`
 	BytesUsed   int     `json:"bytes_used"`

--- a/internal/volumeserver/status.go
+++ b/internal/volumeserver/status.go
@@ -28,7 +28,7 @@ func (s *Server) Status(ctx context.Context, req *iri.StatusRequest) (*iri.Statu
 	for _, volumeClass := range volumeClassList {
 		volumeClassStatus = append(volumeClassStatus, &iri.VolumeClassStatus{
 			VolumeClass: volumeClass,
-			Quantity:    poolStats.MaxAvail,
+			Quantity:    poolStats.MaxAvail + poolStats.Stored,
 		})
 	}
 


### PR DESCRIPTION
# Proposed Changes

- Fix VolumeClass quantity calculation in IRI Status method


Fixes #910 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Volume status now reports total usable capacity by combining available and already-stored capacity.
  - Capacity values support larger storage amounts more reliably, improving reporting for high-capacity environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->