### PR TITLE
Refactor API and controllers

### DIFF
--- a/api/v2/constants.go
+++ b/api/v2/constants.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+const (
+	LabelsAnnotation      = "ceph-provider.ironcore.dev/labels"
+	AnnotationsAnnotation = "ceph-provider.ironcore.dev/annotations"
+	ClassLabel            = "ceph-provider.ironcore.dev/class"
+	ManagerLabel          = "ceph-provider.ironcore.dev/manager"
+	BucketManager         = "ceph-bucket-provider"
+	VolumeManager         = "ceph-volume-provider"
+
+	MachineArchitectureLabel = "common.ironcore.dev/architecture"
+)

--- a/api/v2/image.go
+++ b/api/v2/image.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
+)
+
+const (
+	ImageSpecSnapshotSourceField = "spec.snapshotSource"
+)
+
+func SetupImageSpecSnapshotSourceFieldIndexer(image *Image) string {
+	if image.Spec.SnapshotSource != nil {
+		return *image.Spec.SnapshotSource
+	}
+	return ""
+}
+
+type Image struct {
+	apiutils.Metadata `json:"metadata"`
+
+	Spec   ImageSpec   `json:"spec"`
+	Status ImageStatus `json:"status"`
+}
+
+type ImageState string
+
+const (
+	ImageStatePending   ImageState = "Pending"
+	ImageStateAvailable ImageState = "Available"
+)
+
+type EncryptionState string
+
+const (
+	EncryptionStateHeaderSet EncryptionState = "EncryptionHeaderSet"
+)
+
+type ImageSpec struct {
+	Size       uint64         `json:"size"`
+	WWN        string         `json:"wwn"`
+	Limits     Limits         `json:"limits"`
+	Encryption EncryptionSpec `json:"encryption"`
+
+	// TODO: what is a good name for the image reffor population?
+	Reference *string `json:"reference"`
+
+	SnapshotSource *string `json:"snapshotSource"`
+}
+
+type EncryptionType string
+
+const (
+	EncryptionTypeEncrypted   EncryptionType = "Encrypted"
+	EncryptionTypeUnencrypted EncryptionType = "Unencrypted"
+)
+
+type EncryptionSpec struct {
+	Type                EncryptionType `json:"type"`
+	EncryptedPassphrase []byte         `json:"encryptedPassphrase"`
+}
+
+type ImageStatus struct {
+	State      ImageState      `json:"state"`
+	Encryption EncryptionState `json:"encryption"`
+	Access     *ImageAccess    `json:"access"`
+	Size       uint64          `json:"size"`
+}
+
+type ImageAccess struct {
+	Monitors string `json:"monitors"`
+	Handle   string `json:"handle"`
+
+	User    string `json:"user"`
+	UserKey string `json:"userKey"`
+}
+
+type Limits map[LimitType]int64
+
+const (
+	IOPSLimit                   LimitType = "rbd_qos_iops_limit"
+	IOPSBurstLimit              LimitType = "rbd_qos_iops_burst"
+	IOPSBurstDurationLimit      LimitType = "rbd_qos_iops_burst_seconds"
+	ReadIOPSLimit               LimitType = "rbd_qos_read_iops_limit"
+	ReadIOPSBurstLimit          LimitType = "rbd_qos_read_iops_burst"
+	ReadIOPSBurstDurationLimit  LimitType = "rbd_qos_read_iops_burst_seconds"
+	WriteIOPSLimit              LimitType = "rbd_qos_write_iops_limit"
+	WriteIOPSBurstLimit         LimitType = "rbd_qos_write_iops_burst"
+	WriteIOPSBurstDurationLimit LimitType = "rbd_qos_write_iops_burst_seconds"
+	BPSLimit                    LimitType = "rbd_qos_bps_limit"
+	BPSBurstLimit               LimitType = "rbd_qos_bps_burst"
+	BPSBurstDurationLimit       LimitType = "rbd_qos_bps_burst_seconds"
+	ReadBPSLimit                LimitType = "rbd_qos_read_bps_limit"
+	ReadBPSBurstLimit           LimitType = "rbd_qos_read_bps_burst"
+	ReadBPSBurstDurationLimit   LimitType = "rbd_qos_read_bps_burst_seconds"
+	WriteBPSLimit               LimitType = "rbd_qos_write_bps_limit"
+	WriteBPSBurstLimit          LimitType = "rbd_qos_write_bps_burst"
+	WriteBPSBurstDurationLimit  LimitType = "rbd_qos_write_bps_burst_seconds"
+)
+
+type LimitType string

--- a/api/v2/snapshot.go
+++ b/api/v2/snapshot.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
+)
+
+const (
+	SnapshotSpecImageRefField = "spec.imageRef"
+)
+
+func SetupSnapshotSpecImageRefFieldIndexer(snapshot *Snapshot) string {
+	return snapshot.Spec.ImageRef
+}
+
+type Snapshot struct {
+	apiutils.Metadata `json:"metadata,omitempty"`
+
+	Spec   SnapshotSpec   `json:"spec"`
+	Status SnapshotStatus `json:"status"`
+}
+
+type SnapshotProtection string
+
+const (
+	SnapshotProtectionNone      SnapshotProtection = "none"
+	SnapshotProtectionProtected SnapshotProtection = "protected"
+)
+
+type SnapshotSpec struct {
+	ImageRef   string             `json:"imageRef"`
+	Protection SnapshotProtection `json:"protection"`
+}
+
+type SnapshotState string
+
+const (
+	SnapshotStatePending SnapshotState = "Pending"
+	SnapshotStateReady   SnapshotState = "Ready"
+	SnapshotStateFailed  SnapshotState = "Failed"
+)
+
+type SnapshotStatus struct {
+	State SnapshotState `json:"state"`
+	Size  int64         `json:"size"`
+}

--- a/api/v2/utils.go
+++ b/api/v2/utils.go
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ironcore-dev/controller-utils/metautils"
+	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
+	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
+	objectbucketv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetObjectMetadata(o apiutils.Metadata) (*irimeta.ObjectMetadata, error) {
+	annotations, err := apiutils.GetAnnotationsAnnotation(o, AnnotationsAnnotation)
+	if err != nil {
+		return nil, err
+	}
+
+	labels, err := apiutils.GetLabelsAnnotation(o, LabelsAnnotation)
+	if err != nil {
+		return nil, err
+	}
+
+	var deletedAt int64
+	if o.DeletedAt != nil {
+		deletedAt = o.DeletedAt.UnixNano()
+	}
+
+	return &irimeta.ObjectMetadata{
+		Id:          o.GetID(),
+		Annotations: annotations,
+		Labels:      labels,
+		Generation:  o.GetGeneration(),
+		CreatedAt:   o.GetCreatedAt().UnixNano(),
+		DeletedAt:   deletedAt,
+	}, nil
+}
+
+func GetObjectMetadataFromK8s(o metav1.Object) (*irimeta.ObjectMetadata, error) {
+	annotations, err := GetAnnotationsAnnotation(o)
+	if err != nil {
+		return nil, err
+	}
+
+	labels, err := GetLabelsAnnotation(o)
+	if err != nil {
+		return nil, err
+	}
+
+	var deletedAt int64
+	if !o.GetDeletionTimestamp().IsZero() {
+		deletedAt = o.GetDeletionTimestamp().UnixNano()
+	}
+
+	return &irimeta.ObjectMetadata{
+		Id:          o.GetName(),
+		Annotations: annotations,
+		Labels:      labels,
+		Generation:  o.GetGeneration(),
+		CreatedAt:   o.GetCreationTimestamp().UnixNano(),
+		DeletedAt:   deletedAt,
+	}, nil
+}
+
+func SetObjectMetadata(o metav1.Object, metadata *irimeta.ObjectMetadata) error {
+	if err := SetAnnotationsAnnotation(o, metadata.Annotations); err != nil {
+		return err
+	}
+	if err := SetLabelsAnnotation(o, metadata.Labels); err != nil {
+		return err
+	}
+	return nil
+}
+
+func SetClassLabel(o metav1.Object, class string) {
+	metautils.SetLabel(o, ClassLabel, class)
+}
+
+func GetClassLabel(o metav1.Object) (string, bool) {
+	class, found := o.GetLabels()[ClassLabel]
+	return class, found
+}
+
+func SetLabelsAnnotation(o metav1.Object, labels map[string]string) error {
+	data, err := json.Marshal(labels)
+	if err != nil {
+		return fmt.Errorf("error marshalling labels: %w", err)
+	}
+	metautils.SetAnnotation(o, LabelsAnnotation, string(data))
+	return nil
+}
+
+func GetLabelsAnnotation(o metav1.Object) (map[string]string, error) {
+	data, ok := o.GetAnnotations()[LabelsAnnotation]
+	if !ok {
+		return nil, fmt.Errorf("object has no labels at %s", LabelsAnnotation)
+	}
+
+	var labels map[string]string
+	if err := json.Unmarshal([]byte(data), &labels); err != nil {
+		return nil, err
+	}
+
+	return labels, nil
+}
+
+func SetAnnotationsAnnotation(o metav1.Object, annotations map[string]string) error {
+	data, err := json.Marshal(annotations)
+	if err != nil {
+		return fmt.Errorf("error marshalling annotations: %w", err)
+	}
+	metautils.SetAnnotation(o, AnnotationsAnnotation, string(data))
+	return nil
+}
+
+func GetAnnotationsAnnotation(o metav1.Object) (map[string]string, error) {
+	data, ok := o.GetAnnotations()[AnnotationsAnnotation]
+	if !ok {
+		return nil, fmt.Errorf("object has no annotations at %s", AnnotationsAnnotation)
+	}
+
+	var annotations map[string]string
+	if err := json.Unmarshal([]byte(data), &annotations); err != nil {
+		return nil, err
+	}
+
+	return annotations, nil
+}
+
+func SetBucketManagerLabel(bucket *objectbucketv1alpha1.ObjectBucketClaim, manager string) {
+	metautils.SetLabel(bucket, ManagerLabel, manager)
+}
+
+func IsManagedBy(o metav1.Object, manager string) bool {
+	actual, ok := o.GetLabels()[ManagerLabel]
+	return ok && actual == manager
+}
+
+func GetObjectMetadataFromObjectID(o apiutils.Metadata) (*irimeta.ObjectMetadata, error) {
+	annotations, err := GetAnnotationsAnnotationForMetadata(o)
+	if err != nil {
+		return nil, err
+	}
+
+	labels, err := GetLabelsAnnotationForMetadata(o)
+	if err != nil {
+		return nil, err
+	}
+
+	var deletedAt int64
+	if o.DeletedAt != nil && !o.DeletedAt.IsZero() {
+		deletedAt = o.DeletedAt.UnixNano()
+	}
+
+	return &irimeta.ObjectMetadata{
+		Id:          o.ID,
+		Annotations: annotations,
+		Labels:      labels,
+		Generation:  o.GetGeneration(),
+		CreatedAt:   o.CreatedAt.UnixNano(),
+		DeletedAt:   deletedAt,
+	}, nil
+}
+
+func GetAnnotationsAnnotationForMetadata(o apiutils.Metadata) (map[string]string, error) {
+	data, ok := o.GetAnnotations()[AnnotationsAnnotation]
+	if !ok {
+		return nil, fmt.Errorf("object has no annotations at %s", AnnotationsAnnotation)
+	}
+
+	var annotations map[string]string
+	if err := json.Unmarshal([]byte(data), &annotations); err != nil {
+		return nil, err
+	}
+
+	return annotations, nil
+}
+
+func GetLabelsAnnotationForMetadata(o apiutils.Metadata) (map[string]string, error) {
+	data, ok := o.GetAnnotations()[LabelsAnnotation]
+	if !ok {
+		return nil, fmt.Errorf("object has no labels at %s", LabelsAnnotation)
+	}
+
+	var labels map[string]string
+	if err := json.Unmarshal([]byte(data), &labels); err != nil {
+		return nil, err
+	}
+
+	return labels, nil
+}
+
+func GetClassLabelFromObject(o apiutils.Object) (string, bool) {
+	class, found := o.GetLabels()[ClassLabel]
+	return class, found
+}
+
+func SetObjectMetadataFromMetadata(o apiutils.Object, metadata *irimeta.ObjectMetadata) error {
+	if err := SetAnnotationsAnnotationForObject(o, metadata.Annotations); err != nil {
+		return err
+	}
+	if err := SetLabelsAnnotationForOject(o, metadata.Labels); err != nil {
+		return err
+	}
+	return nil
+}
+
+func SetLabelsAnnotationForOject(o apiutils.Object, labels map[string]string) error {
+	data, err := json.Marshal(labels)
+	if err != nil {
+		return fmt.Errorf("error marshalling labels: %w", err)
+	}
+	metautils.SetAnnotation(o, LabelsAnnotation, string(data))
+	return nil
+}
+
+func SetAnnotationsAnnotationForObject(o apiutils.Object, annotations map[string]string) error {
+	data, err := json.Marshal(annotations)
+	if err != nil {
+		return fmt.Errorf("error marshalling annotations: %w", err)
+	}
+	metautils.SetAnnotation(o, AnnotationsAnnotation, string(data))
+
+	return nil
+}
+
+func SetClassLabelForObject(o apiutils.Object, class string) {
+	metautils.SetLabel(o, ClassLabel, class)
+}
+
+func IsObjectManagedBy(o apiutils.Object, manager string) bool {
+	actual, ok := o.GetLabels()[ManagerLabel]
+	return ok && actual == manager
+}
+
+func SetManagerLabel(o apiutils.Object, manager string) {
+	metautils.SetLabel(o, ManagerLabel, manager)
+}

--- a/api/v2/volume.go
+++ b/api/v2/volume.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
+)
+
+const (
+	VolumeStatusImageRefField           = "status.imageRef"
+	VolumeSpecSourceSnapshotSourceField = "spec.source.snapshotSource"
+)
+
+func SetupVolumeStatusImageRefFieldIndexer(volume *Volume) string {
+	return volume.Status.ImageRef
+}
+
+func SetupVolumeSpecSourceSnapshotSourceFieldIndexer(volume *Volume) string {
+	if volume.Spec.Source.SnapshotSource != nil {
+		return *volume.Spec.Source.SnapshotSource
+	}
+	return ""
+}
+
+type Volume struct {
+	apiutils.Metadata `json:"metadata,omitempty"`
+
+	Spec   VolumeSpec   `json:"spec"`
+	Status VolumeStatus `json:"status"`
+}
+
+type VolumeState string
+
+const (
+	VolumeStatePending   VolumeState = "Pending"
+	VolumeStateAvailable VolumeState = "Available"
+)
+
+type VolumeEncryptionState string
+
+const (
+	VolumeEncryptionStateHeaderSet VolumeEncryptionState = "VolumeEncryptionHeaderSet"
+)
+
+type VolumeSpec struct {
+	Size             uint64               `json:"size"`
+	WWN              string               `json:"wwn"`
+	Limits           Limits               `json:"limits"`
+	VolumeEncryption VolumeEncryptionSpec `json:"encryption"`
+
+	Source VolumeSource `json:"source"`
+}
+
+type VolumeSource struct {
+	OSVolume       *OSVolumeSource `json:"osVolume"`
+	SnapshotSource *string         `json:"snapshotSource"`
+}
+
+type OSVolumeSource struct {
+	Name         string  `json:"name"`
+	Architecture *string `json:"architecture"`
+}
+
+type VolumeEncryptionType string
+
+const (
+	VolumeEncryptionTypeEncrypted   VolumeEncryptionType = "Encrypted"
+	VolumeEncryptionTypeUnencrypted VolumeEncryptionType = "Unencrypted"
+)
+
+type VolumeEncryptionSpec struct {
+	Type                VolumeEncryptionType `json:"type"`
+	EncryptedPassphrase []byte               `json:"encryptedPassphrase"`
+}
+
+type VolumeStatus struct {
+	State            VolumeState           `json:"state"`
+	VolumeEncryption VolumeEncryptionState `json:"encryption"`
+	Access           *VolumeAccess         `json:"access"`
+	Size             uint64                `json:"size"`
+	ImageRef         string                `json:"imageRef"`
+}
+
+type VolumeAccess struct {
+	Monitors string `json:"monitors"`
+	Handle   string `json:"handle"`
+
+	User    string `json:"user"`
+	UserKey string `json:"userKey"`
+}

--- a/cmd/volumeprovider/app/app.go
+++ b/cmd/volumeprovider/app/app.go
@@ -13,13 +13,17 @@ import (
 
 	"github.com/go-logr/logr"
 	providerapi "github.com/ironcore-dev/ceph-provider/api"
+	apiv2 "github.com/ironcore-dev/ceph-provider/api/v2"
 	"github.com/ironcore-dev/ceph-provider/internal/ceph"
 	"github.com/ironcore-dev/ceph-provider/internal/controllers"
+	controllersv2 "github.com/ironcore-dev/ceph-provider/internal/controllers/v2"
 	"github.com/ironcore-dev/ceph-provider/internal/encryption"
 	"github.com/ironcore-dev/ceph-provider/internal/omap"
 	"github.com/ironcore-dev/ceph-provider/internal/strategy"
 	"github.com/ironcore-dev/ceph-provider/internal/vcr"
 	"github.com/ironcore-dev/ceph-provider/internal/volumeserver"
+	volumeserverv2 "github.com/ironcore-dev/ceph-provider/internal/volumeserver/v2"
+	"github.com/ironcore-dev/ironcore-image/oci/remote"
 	"github.com/ironcore-dev/ironcore/broker/common"
 	iriv1alpha1 "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 	"github.com/ironcore-dev/provider-utils/eventutils/event"
@@ -37,6 +41,8 @@ type Options struct {
 	Address string
 
 	PathSupportedVolumeClasses string
+
+	EnableV2 bool
 
 	Ceph CephOptions
 }
@@ -77,6 +83,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Address, "address", "/var/run/iri-volumeprovider.sock", "Address to listen on.")
 
 	fs.StringVar(&o.PathSupportedVolumeClasses, "supported-volume-classes", o.PathSupportedVolumeClasses, "File containing supported volume classes.")
+
+	fs.BoolVar(&o.EnableV2, "enable-v2", false, "Enable v2 volume-centric API and controllers.")
 
 	fs.Int64Var(&o.Ceph.BurstFactor, "limits-burst-factor", o.Ceph.BurstFactor, "Defines the factor to calculate the burst limits.")
 	fs.Int64Var(&o.Ceph.BurstDurationInSeconds, "limits-burst-duration", o.Ceph.BurstDurationInSeconds, "Defines the burst duration in seconds.")
@@ -211,9 +219,9 @@ func Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("configuration invalid: %w", err)
 	}
 
-	setupLog.Info("Configuring image store", "OmapName", omap.NameVolumes)
+	setupLog.Info("Configuring image store", "OmapName", omap.LegacyNameVolumes)
 	imageStore, err := omap.New(log.WithName("image-events"), conn, opts.Ceph.Pool, omap.Options[*providerapi.Image]{
-		OmapName:       omap.NameVolumes,
+		OmapName:       omap.LegacyNameVolumes,
 		NewFunc:        func() *providerapi.Image { return &providerapi.Image{} },
 		CreateStrategy: strategy.ImageStrategy,
 		IteratorSize:   opts.Ceph.OmapIteratorSize,
@@ -234,9 +242,9 @@ func Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("failed to initialize image events: %w", err)
 	}
 
-	setupLog.Info("Configuring snapshot store", "OmapName", omap.NameSnapshots)
+	setupLog.Info("Configuring snapshot store", "OmapName", omap.LegacyNameSnapshots)
 	snapshotStore, err := omap.New(log.WithName("snapshot-events"), conn, opts.Ceph.Pool, omap.Options[*providerapi.Snapshot]{
-		OmapName:       omap.NameSnapshots,
+		OmapName:       omap.LegacyNameSnapshots,
 		NewFunc:        func() *providerapi.Snapshot { return &providerapi.Snapshot{} },
 		CreateStrategy: strategy.SnapshotStrategy,
 		IteratorSize:   opts.Ceph.OmapIteratorSize,
@@ -256,78 +264,80 @@ func Run(ctx context.Context, opts Options) error {
 
 	volumeEventStore := eventrecorder.NewEventStore(log, opts.Ceph.VolumeEventStoreOptions)
 
-	imageReconciler, err := controllers.NewImageReconciler(
-		log.WithName("image-reconciler"),
-		conn,
-		imageStore, snapshotStore,
-		volumeEventStore,
-		imageEvents,
-		snapshotEvents,
-		encryptor,
-		controllers.ImageReconcilerOptions{
-			Monitors:   opts.Ceph.Monitors,
-			Client:     opts.Ceph.Client,
-			Pool:       opts.Ceph.Pool,
-			WorkerSize: opts.Ceph.WorkerSize,
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed to initialize image reconciler: %w", err)
-	}
-
 	g, ctx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
-		setupLog.Info("Starting image reconciler")
-		if err := imageReconciler.Start(ctx); err != nil {
-			setupLog.Error(err, "failed to start image reconciler")
-			return err
+	if !opts.EnableV2 {
+		imageReconciler, err := controllers.NewImageReconciler(
+			log.WithName("image-reconciler"),
+			conn,
+			imageStore, snapshotStore,
+			volumeEventStore,
+			imageEvents,
+			snapshotEvents,
+			encryptor,
+			controllers.ImageReconcilerOptions{
+				Monitors:   opts.Ceph.Monitors,
+				Client:     opts.Ceph.Client,
+				Pool:       opts.Ceph.Pool,
+				WorkerSize: opts.Ceph.WorkerSize,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to initialize image reconciler: %w", err)
 		}
-		return nil
-	})
 
-	snapshotReconciler, err := controllers.NewSnapshotReconciler(
-		log.WithName("snapshot-reconciler"),
-		conn,
-		snapshotStore,
-		imageStore,
-		snapshotEvents,
-		controllers.SnapshotReconcilerOptions{
-			Pool:                opts.Ceph.Pool,
-			PopulatorBufferSize: opts.Ceph.PopulatorBufferSize,
-			WorkerSize:          opts.Ceph.WorkerSize,
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed to initialize snapshot reconciler: %w", err)
+		g.Go(func() error {
+			setupLog.Info("Starting image reconciler")
+			if err := imageReconciler.Start(ctx); err != nil {
+				setupLog.Error(err, "failed to start image reconciler")
+				return err
+			}
+			return nil
+		})
+
+		snapshotReconciler, err := controllers.NewSnapshotReconciler(
+			log.WithName("snapshot-reconciler"),
+			conn,
+			snapshotStore,
+			imageStore,
+			snapshotEvents,
+			controllers.SnapshotReconcilerOptions{
+				Pool:                opts.Ceph.Pool,
+				PopulatorBufferSize: opts.Ceph.PopulatorBufferSize,
+				WorkerSize:          opts.Ceph.WorkerSize,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to initialize snapshot reconciler: %w", err)
+		}
+
+		g.Go(func() error {
+			setupLog.Info("Starting snapshot reconciler")
+			if err := snapshotReconciler.Start(ctx); err != nil {
+				setupLog.Error(err, "failed to start snapshot reconciler")
+				return err
+			}
+			return nil
+		})
+
+		g.Go(func() error {
+			setupLog.Info("Starting image events")
+			if err := imageEvents.Start(ctx); err != nil {
+				setupLog.Error(err, "failed to start image events")
+				return err
+			}
+			return nil
+		})
+
+		g.Go(func() error {
+			setupLog.Info("Starting snapshot events")
+			if err := snapshotEvents.Start(ctx); err != nil {
+				setupLog.Error(err, "failed to start snapshot events")
+				return err
+			}
+			return nil
+		})
 	}
-
-	g.Go(func() error {
-		setupLog.Info("Starting snapshot reconciler")
-		if err := snapshotReconciler.Start(ctx); err != nil {
-			setupLog.Error(err, "failed to start snapshot reconciler")
-			return err
-		}
-		return nil
-	})
-
-	g.Go(func() error {
-		setupLog.Info("Starting image events")
-		if err := imageEvents.Start(ctx); err != nil {
-			setupLog.Error(err, "failed to start image events")
-			return err
-		}
-		return nil
-	})
-
-	g.Go(func() error {
-		setupLog.Info("Starting snapshot events")
-		if err := snapshotEvents.Start(ctx); err != nil {
-			setupLog.Error(err, "failed to start snapshot events")
-			return err
-		}
-		return nil
-	})
 
 	g.Go(func() error {
 		setupLog.Info("Starting volume events garbage collector")
@@ -350,25 +360,226 @@ func Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("failed to initialize ceph command client: %w", err)
 	}
 
-	srv, err := volumeserver.New(
-		imageStore,
-		snapshotStore,
-		classRegistry,
-		encryptor,
-		cephCommandClient,
-		volumeserver.Options{
-			VolumeEventStore:       volumeEventStore,
-			BurstFactor:            opts.Ceph.BurstFactor,
-			BurstDurationInSeconds: opts.Ceph.BurstDurationInSeconds,
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("error creating server: %w", err)
+	var iriServer iriv1alpha1.VolumeRuntimeServer
+
+	if opts.EnableV2 {
+		setupLog.Info("V2 mode enabled: configuring volume-centric pipeline")
+
+		setupLog.Info("Configuring v2 volume store", "OmapName", omap.NameVolumes)
+		volumeStore, err := omap.New(log, conn, opts.Ceph.Pool, omap.Options[*apiv2.Volume]{
+			OmapName:       omap.NameVolumes,
+			NewFunc:        func() *apiv2.Volume { return &apiv2.Volume{} },
+			CreateStrategy: strategy.VolumeStrategy,
+			FieldIndexers: map[string]store.IndexerFunc[*apiv2.Volume]{
+				apiv2.VolumeStatusImageRefField:           apiv2.SetupVolumeStatusImageRefFieldIndexer,
+				apiv2.VolumeSpecSourceSnapshotSourceField: apiv2.SetupVolumeSpecSourceSnapshotSourceFieldIndexer,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to initialize v2 volume store: %w", err)
+		}
+
+		volumeEvents, err := event.NewListWatchSource[*apiv2.Volume](
+			volumeStore.List,
+			volumeStore.Watch,
+			event.ListWatchSourceOptions{},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to initialize volume events: %w", err)
+		}
+
+		v2ImageStore, err := omap.New(log, conn, opts.Ceph.Pool, omap.Options[*apiv2.Image]{
+			OmapName:       omap.NameImages,
+			NewFunc:        func() *apiv2.Image { return &apiv2.Image{} },
+			CreateStrategy: strategy.ImageV2Strategy,
+			FieldIndexers: map[string]store.IndexerFunc[*apiv2.Image]{
+				apiv2.ImageSpecSnapshotSourceField: apiv2.SetupImageSpecSnapshotSourceFieldIndexer,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to initialize v2 image store: %w", err)
+		}
+
+		v2ImageEvents, err := event.NewListWatchSource[*apiv2.Image](
+			v2ImageStore.List,
+			v2ImageStore.Watch,
+			event.ListWatchSourceOptions{},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to initialize v2 image events: %w", err)
+		}
+
+		v2SnapshotStore, err := omap.New(log, conn, opts.Ceph.Pool, omap.Options[*apiv2.Snapshot]{
+			OmapName:       omap.NameSnapshots,
+			NewFunc:        func() *apiv2.Snapshot { return &apiv2.Snapshot{} },
+			CreateStrategy: strategy.SnapshotV2Strategy,
+			FieldIndexers: map[string]store.IndexerFunc[*apiv2.Snapshot]{
+				apiv2.SnapshotSpecImageRefField: apiv2.SetupSnapshotSpecImageRefFieldIndexer,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to initialize v2 snapshot store: %w", err)
+		}
+
+		v2SnapshotEvents, err := event.NewListWatchSource[*apiv2.Snapshot](
+			v2SnapshotStore.List,
+			v2SnapshotStore.Watch,
+			event.ListWatchSourceOptions{},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to initialize v2 snapshot events: %w", err)
+		}
+
+		ociRegistry, err := remote.DockerRegistry()
+		if err != nil {
+			return fmt.Errorf("failed to initialize OCI registry: %w", err)
+		}
+
+		volumeReconciler, err := controllersv2.NewVolumeReconciler(
+			log.WithName("volume-reconciler"),
+			ociRegistry,
+			v2SnapshotStore,
+			v2ImageStore,
+			volumeStore,
+			volumeEvents,
+			v2ImageEvents,
+			v2SnapshotEvents,
+			controllersv2.VolumeReconcilerOptions{
+				WorkerSize: opts.Ceph.WorkerSize,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to initialize volume reconciler: %w", err)
+		}
+
+		g.Go(func() error {
+			setupLog.Info("Starting v2 volume reconciler")
+			if err := volumeReconciler.Start(ctx); err != nil {
+				setupLog.Error(err, "failed to start volume reconciler")
+				return err
+			}
+			return nil
+		})
+
+		imageReconciler, err := controllersv2.NewImageReconciler(
+			log.WithName("image-reconciler"),
+			conn,
+			v2ImageStore,
+			v2SnapshotStore,
+			v2ImageEvents,
+			v2SnapshotEvents,
+			encryptor,
+			controllersv2.ImageReconcilerOptions{
+				Monitors:            opts.Ceph.Monitors,
+				Client:              opts.Ceph.Client,
+				Pool:                opts.Ceph.Pool,
+				PopulatorBufferSize: opts.Ceph.PopulatorBufferSize,
+				WorkerSize:          opts.Ceph.WorkerSize,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to initialize v2 image reconciler: %w", err)
+		}
+
+		g.Go(func() error {
+			setupLog.Info("Starting v2 image reconciler")
+			if err := imageReconciler.Start(ctx); err != nil {
+				setupLog.Error(err, "failed to start v2 image reconciler")
+				return err
+			}
+			return nil
+		})
+
+		snapshotReconciler, err := controllersv2.NewSnapshotReconciler(
+			log.WithName("snapshot-reconciler"),
+			conn,
+			v2SnapshotStore,
+			v2ImageStore,
+			v2SnapshotEvents,
+			v2ImageEvents,
+			controllersv2.SnapshotReconcilerOptions{
+				Pool:       opts.Ceph.Pool,
+				WorkerSize: opts.Ceph.WorkerSize,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to initialize v2 snapshot reconciler: %w", err)
+		}
+
+		g.Go(func() error {
+			setupLog.Info("Starting v2 snapshot reconciler")
+			if err := snapshotReconciler.Start(ctx); err != nil {
+				setupLog.Error(err, "failed to start v2 snapshot reconciler")
+				return err
+			}
+			return nil
+		})
+
+		g.Go(func() error {
+			setupLog.Info("Starting v2 volume events")
+			if err := volumeEvents.Start(ctx); err != nil {
+				setupLog.Error(err, "failed to start volume events")
+				return err
+			}
+			return nil
+		})
+
+		g.Go(func() error {
+			setupLog.Info("Starting v2 image events")
+			if err := v2ImageEvents.Start(ctx); err != nil {
+				setupLog.Error(err, "failed to start v2 image events")
+				return err
+			}
+			return nil
+		})
+
+		g.Go(func() error {
+			setupLog.Info("Starting v2 snapshot events")
+			if err := v2SnapshotEvents.Start(ctx); err != nil {
+				setupLog.Error(err, "failed to start v2 snapshot events")
+				return err
+			}
+			return nil
+		})
+
+		srv, err := volumeserverv2.New(
+			volumeStore,
+			v2SnapshotStore,
+			classRegistry,
+			encryptor,
+			cephCommandClient,
+			volumeserverv2.Options{
+				VolumeEventStore:       volumeEventStore,
+				BurstFactor:            opts.Ceph.BurstFactor,
+				BurstDurationInSeconds: opts.Ceph.BurstDurationInSeconds,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("error creating v2 server: %w", err)
+		}
+		iriServer = srv
+	} else {
+		srv, err := volumeserver.New(
+			imageStore,
+			snapshotStore,
+			classRegistry,
+			encryptor,
+			cephCommandClient,
+			volumeserver.Options{
+				VolumeEventStore:       volumeEventStore,
+				BurstFactor:            opts.Ceph.BurstFactor,
+				BurstDurationInSeconds: opts.Ceph.BurstDurationInSeconds,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("error creating server: %w", err)
+		}
+		iriServer = srv
 	}
 
 	g.Go(func() error {
 		setupLog.Info("Starting grpc server")
-		if err := runGRPCServer(ctx, setupLog, log, srv, opts); err != nil {
+		if err := runGRPCServer(ctx, setupLog, log, iriServer, opts); err != nil {
 			setupLog.Error(err, "failed to start grpc server")
 			return err
 		}
@@ -377,7 +588,7 @@ func Run(ctx context.Context, opts Options) error {
 	return g.Wait()
 }
 
-func runGRPCServer(ctx context.Context, setupLog logr.Logger, log logr.Logger, srv *volumeserver.Server, opts Options) error {
+func runGRPCServer(ctx context.Context, setupLog logr.Logger, log logr.Logger, srv iriv1alpha1.VolumeRuntimeServer, opts Options) error {
 	setupLog.V(1).Info("Cleaning up any previous socket")
 	if err := common.CleanupSocketIfExists(opts.Address); err != nil {
 		return fmt.Errorf("error cleaning up socket: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/ceph/go-ceph v0.40.0
 	github.com/containerd/containerd v1.7.34
+	github.com/distribution/reference v0.6.0
 	github.com/go-logr/logr v1.4.4
 	github.com/google/addlicense v1.2.0
 	github.com/ironcore-dev/controller-utils v0.12.0
@@ -27,6 +28,7 @@ require (
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570
+	oras.land/oras-go/v2 v2.6.1
 	sigs.k8s.io/controller-runtime v0.23.3
 )
 
@@ -138,7 +140,6 @@ require (
 	k8s.io/component-base v0.35.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect
-	oras.land/oras-go/v2 v2.6.1 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=

--- a/internal/controllers/v2/common.go
+++ b/internal/controllers/v2/common.go
@@ -1,0 +1,1 @@
+package controllers

--- a/internal/controllers/v2/common.go
+++ b/internal/controllers/v2/common.go
@@ -4,15 +4,65 @@
 package controllers
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"slices"
 
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/go-logr/logr"
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
 	"github.com/ironcore-dev/ironcore-image/oci/image"
 	"github.com/ironcore-dev/ironcore-image/oci/remote"
+	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"k8s.io/utils/ptr"
 )
+
+// removeFinalizer removes fin from obj's finalizers and persists it if present.
+func removeFinalizer[T apiutils.Object](ctx context.Context, s store.Store[T], obj T, fin string) (T, error) {
+	if !slices.Contains(obj.GetFinalizers(), fin) {
+		return obj, nil
+	}
+	obj.SetFinalizers(utils.DeleteSliceElement(obj.GetFinalizers(), fin))
+	updated, err := s.Update(ctx, obj)
+	if err != nil {
+		return obj, fmt.Errorf("failed to remove finalizer %q from %T: %w", fin, obj, err)
+	}
+	return updated, nil
+}
+
+// addFinalizer adds fin to obj's finalizers and persists it if not already present.
+func addFinalizer[T apiutils.Object](ctx context.Context, s store.Store[T], obj T, fin string) (T, error) {
+	if slices.Contains(obj.GetFinalizers(), fin) {
+		return obj, nil
+	}
+	obj.SetFinalizers(append(obj.GetFinalizers(), fin))
+	updated, err := s.Update(ctx, obj)
+	if err != nil {
+		return obj, fmt.Errorf("failed to set finalizer %q on %T: %w", fin, obj, err)
+	}
+	return updated, nil
+}
+
+// createOrGet creates obj in the store. If the object already exists it fetches and returns it instead.
+func createOrGet[T apiutils.Object](ctx context.Context, log logr.Logger, s store.Store[T], obj T, createdMsg, existsMsg string) (T, error) {
+	created, err := s.Create(ctx, obj)
+	if err != nil {
+		if !errors.Is(err, store.ErrAlreadyExists) {
+			return obj, fmt.Errorf("failed to create %T: %w", obj, err)
+		}
+		log.V(2).Info(existsMsg, "id", obj.GetID())
+		existing, err := s.Get(ctx, obj.GetID())
+		if err != nil {
+			return obj, fmt.Errorf("failed to get existing %T: %w", obj, err)
+		}
+		return existing, nil
+	}
+	log.V(1).Info(createdMsg, "id", created.GetID())
+	return created, nil
+}
 
 func closeImage(log logr.Logger, img *librbd.Image) {
 	if img == nil {

--- a/internal/controllers/v2/common.go
+++ b/internal/controllers/v2/common.go
@@ -1,1 +1,44 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
+
+import (
+	"errors"
+
+	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/go-logr/logr"
+	"github.com/ironcore-dev/ironcore-image/oci/image"
+	"github.com/ironcore-dev/ironcore-image/oci/remote"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"k8s.io/utils/ptr"
+)
+
+func closeImage(log logr.Logger, img *librbd.Image) {
+	if img == nil {
+		log.Error(errors.New("image is nil"), "failed to close image")
+		return
+	}
+	if err := img.Close(); err != nil && !errors.Is(err, librbd.ErrImageNotOpen) {
+		log.Error(err, "failed to close image")
+	}
+}
+
+func createImageSource(platform *ocispec.Platform) (image.Source, error) {
+	if platform == nil {
+		return remote.DockerRegistry()
+	}
+
+	return remote.DockerRegistryWithPlatform(platform)
+}
+
+func toPlatform(arch *string) *ocispec.Platform {
+	if arch == nil {
+		return nil
+	}
+
+	return &ocispec.Platform{
+		Architecture: ptr.Deref(arch, ""),
+		OS:           "linux",
+	}
+}

--- a/internal/controllers/v2/image_controller.go
+++ b/internal/controllers/v2/image_controller.go
@@ -1,0 +1,598 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/ceph/go-ceph/rados"
+	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/go-logr/logr"
+	providerapi "github.com/ironcore-dev/ceph-provider/api/v2"
+	"github.com/ironcore-dev/ceph-provider/internal/encryption"
+	"github.com/ironcore-dev/ceph-provider/internal/rater"
+	"github.com/ironcore-dev/ceph-provider/internal/round"
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	"github.com/ironcore-dev/provider-utils/eventutils/event"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
+	"k8s.io/client-go/util/workqueue"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
+)
+
+const (
+	LimitMetadataPrefix = "conf_"
+	WWNKey              = "wwn"
+)
+
+type ImageReconcilerOptions struct {
+	Monitors            string
+	Client              string
+	Pool                string
+	PopulatorBufferSize int64
+	WorkerSize          int
+}
+
+func NewImageReconciler(
+	log logr.Logger,
+	conn *rados.Conn,
+	imageStore store.Store[*providerapi.Image],
+	snapshotStore store.Store[*providerapi.Snapshot],
+	imageEvents event.Source[*providerapi.Image],
+	snapshotEvents event.Source[*providerapi.Snapshot],
+	keyEncryption encryption.Encryptor,
+	opts ImageReconcilerOptions,
+) (*ImageReconciler, error) {
+	if conn == nil {
+		return nil, fmt.Errorf("must specify conn")
+	}
+
+	if imageStore == nil {
+		return nil, fmt.Errorf("must specify image store")
+	}
+
+	if snapshotStore == nil {
+		return nil, fmt.Errorf("must specify snapshot store")
+	}
+
+	if imageEvents == nil {
+		return nil, fmt.Errorf("must specify image events")
+	}
+
+	if snapshotEvents == nil {
+		return nil, fmt.Errorf("must specify snapshot events")
+	}
+
+	if keyEncryption == nil {
+		return nil, fmt.Errorf("must specify key encryption")
+	}
+
+	if opts.Pool == "" {
+		return nil, fmt.Errorf("must specify pool")
+	}
+
+	if opts.Monitors == "" {
+		return nil, fmt.Errorf("must specify monitors")
+	}
+
+	if opts.Client == "" {
+		return nil, fmt.Errorf("must specify ceph client")
+	}
+
+	if opts.PopulatorBufferSize == 0 {
+		opts.PopulatorBufferSize = 5 * 1024 * 1024
+	}
+
+	if opts.WorkerSize == 0 {
+		opts.WorkerSize = 15
+	}
+
+	return &ImageReconciler{
+		log:                 log,
+		conn:                conn,
+		queue:               workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]()),
+		imageStore:          imageStore,
+		snapshotStore:       snapshotStore,
+		imageEvents:         imageEvents,
+		snapshotEvents:      snapshotEvents,
+		monitors:            opts.Monitors,
+		client:              opts.Client,
+		pool:                opts.Pool,
+		keyEncryption:       keyEncryption,
+		populatorBufferSize: opts.PopulatorBufferSize,
+		workerSize:          opts.WorkerSize,
+	}, nil
+}
+
+type ImageReconciler struct {
+	log  logr.Logger
+	conn *rados.Conn
+
+	queue workqueue.TypedRateLimitingInterface[string]
+
+	imageStore    store.Store[*providerapi.Image]
+	snapshotStore store.Store[*providerapi.Snapshot]
+
+	imageEvents    event.Source[*providerapi.Image]
+	snapshotEvents event.Source[*providerapi.Snapshot]
+
+	monitors string
+	client   string
+	pool     string
+
+	keyEncryption       encryption.Encryptor
+	populatorBufferSize int64
+
+	workerSize int
+}
+
+func (r *ImageReconciler) Start(ctx context.Context) error {
+	log := r.log
+
+	imgEventReg, err := r.imageEvents.AddHandler(event.HandlerFunc[*providerapi.Image](func(evt event.Event[*providerapi.Image]) {
+		r.queue.Add(evt.Object.ID)
+	}))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = r.imageEvents.RemoveHandler(imgEventReg)
+	}()
+
+	snapEventReg, err := r.snapshotEvents.AddHandler(event.HandlerFunc[*providerapi.Snapshot](func(evt event.Event[*providerapi.Snapshot]) {
+		if evt.Type != event.TypeUpdated && evt.Type != event.TypeDeleted {
+			return
+		}
+		if evt.Object.Status.State != providerapi.SnapshotStateReady &&
+			evt.Object.Status.State != providerapi.SnapshotStateFailed &&
+			evt.Object.DeletedAt == nil {
+			return
+		}
+		r.requeueImagesForSnapshot(ctx, evt.Object.ID)
+	}))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = r.snapshotEvents.RemoveHandler(snapEventReg)
+	}()
+
+	go func() {
+		<-ctx.Done()
+		r.queue.ShutDown()
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < r.workerSize; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for r.processNextWorkItem(ctx, log) {
+			}
+		}()
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func (r *ImageReconciler) requeueImagesForSnapshot(ctx context.Context, snapshotID string) {
+	images, err := r.imageStore.List(ctx, store.MatchingFields{providerapi.ImageSpecSnapshotSourceField: snapshotID})
+	if err != nil {
+		r.log.Error(err, "failed to list images for snapshot event requeue")
+		return
+	}
+	for _, img := range images {
+		r.queue.Add(img.ID)
+	}
+}
+
+func (r *ImageReconciler) processNextWorkItem(ctx context.Context, log logr.Logger) bool {
+	id, shutdown := r.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer r.queue.Done(id)
+
+	log = log.WithValues("imageId", id)
+	ctx = logr.NewContext(ctx, log)
+
+	if err := r.reconcileImage(ctx, id); err != nil {
+		log.Error(err, "failed to reconcile image")
+		r.queue.AddRateLimited(id)
+		return true
+	}
+
+	r.queue.Forget(id)
+	return true
+}
+
+const (
+	imageFinalizer = "image"
+)
+
+func (r *ImageReconciler) reconcileImage(ctx context.Context, id string) error {
+	log := logr.FromContextOrDiscard(ctx)
+
+	log.V(2).Info("Get image from store")
+	image, err := r.imageStore.Get(ctx, id)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("failed to fetch image from store: %w", err)
+		}
+		return nil
+	}
+
+	if image.DeletedAt != nil {
+		if err := r.deleteImage(ctx, log, image); err != nil {
+			return fmt.Errorf("failed to delete image: %w", err)
+		}
+		return nil
+	}
+
+	if !slices.Contains(image.Finalizers, imageFinalizer) {
+		image.Finalizers = append(image.Finalizers, imageFinalizer)
+		if _, err := r.imageStore.Update(ctx, image); err != nil {
+			return fmt.Errorf("failed to set finalizers: %w", err)
+		}
+		return nil
+	}
+
+	ioCtx, err := r.conn.OpenIOContext(r.pool)
+	if err != nil {
+		return fmt.Errorf("unable to get rados io context: %w", err)
+	}
+	defer ioCtx.Destroy()
+
+	rbdImage, err := librbd.OpenImage(ioCtx, image.ID, librbd.NoSnapshot)
+	if err != nil {
+		if !errors.Is(err, librbd.ErrNotFound) {
+			return fmt.Errorf("failed to open RBD image: %w", err)
+		}
+		log.V(2).Info("RBD image not found, creating")
+		if ok, err := r.createImage(ctx, ioCtx, log, image); err != nil {
+			return fmt.Errorf("failed to create RBD image: %w", err)
+		} else if !ok {
+			// Image creation is not yet complete
+			return nil
+		}
+		rbdImage, err = librbd.OpenImage(ioCtx, image.ID, librbd.NoSnapshot)
+		if err != nil {
+			return fmt.Errorf("failed to open RBD image after creation: %w", err)
+		}
+	}
+	defer closeImage(log, rbdImage)
+
+	// TODO: The if condition here is not a sufficient check for population.
+	// Multiple workers could run into this and start populating in parallel
+	if image.Status.State == providerapi.ImageStatePending && image.Spec.Reference != nil {
+		// TODO: Run populate asynchronously
+		if err := populateImage(ctx, *image.Spec.Reference, rbdImage, r.populatorBufferSize); err != nil {
+			return fmt.Errorf("failed to populate image: %w", err)
+		}
+	}
+
+	if image.Spec.SnapshotSource != nil {
+		snapshotID := *image.Spec.SnapshotSource
+		snapshot, err := r.snapshotStore.Get(ctx, snapshotID)
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("failed to get source snapshot from store: %w", err)
+		}
+		// Flatten images if their snapshot source is deleted
+		if snapshot == nil || snapshot.DeletedAt != nil {
+			if _, err := rbdImage.GetParent(); err != nil {
+				if !errors.Is(err, librbd.ErrNotFound) {
+					return fmt.Errorf("failed to get RBD parent snapshot: %w", err)
+				}
+				log.V(2).Info("RBD image is flattened", "snapshotId", snapshotID)
+			} else {
+				log.V(1).Info("Flattening RBD image", "snapshotId", snapshotID)
+				// TODO: Run flatten asynchronously
+				if err := rbdImage.Flatten(); err != nil {
+					return fmt.Errorf("failed to flatten RBD image: %w", err)
+				}
+				log.V(1).Info("RBD image successfully flattened", "snapshotId", snapshotID)
+			}
+
+			// Remove finalizer from source snapshot to signal the image has been flattened,
+			// so the image is no longer connected to the snapshot
+			if snapshot != nil {
+				sourceSnapshotFinalizer := fmt.Sprintf("%s/%s", imageFinalizer, image.ID)
+				if slices.Contains(snapshot.Finalizers, sourceSnapshotFinalizer) {
+					snapshot.Finalizers = utils.DeleteSliceElement(snapshot.Finalizers, sourceSnapshotFinalizer)
+					if _, err := r.snapshotStore.Update(ctx, snapshot); err != nil {
+						return fmt.Errorf("failed to set finalizers on source snapshot: %w", err)
+					}
+					log.V(2).Info("Removed finalizer from source snapshot", "snapshotId", snapshot.ID)
+				}
+			}
+		}
+	} else {
+		if parent, err := rbdImage.GetParent(); err != nil {
+			if !errors.Is(err, librbd.ErrNotFound) {
+				return fmt.Errorf("failed to get RBD image parent info: %w", err)
+			}
+		} else {
+			log.V(1).Info("Image has no snapshot source configured, but has a parent in Ceph. Flattening image", "snapshotId", parent.Snap.SnapName)
+			// TODO: Run flatten asynchronously
+			if err := rbdImage.Flatten(); err != nil {
+				return fmt.Errorf("failed to flatten image: %w", err)
+			}
+			log.V(1).Info("Image successfully flattened", "snapshotId", parent.Snap.SnapName)
+		}
+	}
+
+	if image.Status.Encryption != providerapi.EncryptionStateHeaderSet && image.Spec.Encryption.Type == providerapi.EncryptionTypeEncrypted {
+		passphrase, err := r.keyEncryption.Decrypt(image.Spec.Encryption.EncryptedPassphrase)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt passphrase: %w", err)
+		}
+
+		if err := rbdImage.EncryptionFormat(librbd.EncryptionOptionsLUKS2{
+			Alg:        librbd.EncryptionAlgorithmAES256,
+			Passphrase: passphrase,
+		}); err != nil {
+			return fmt.Errorf("failed to set encryption format: %w", err)
+		}
+		image.Status.Encryption = providerapi.EncryptionStateHeaderSet
+		if _, err = r.imageStore.Update(ctx, image); err != nil {
+			return fmt.Errorf("failed to update image metadata: %w", err)
+		}
+		return nil
+	}
+
+	metadata, err := rbdImage.ListMetadata()
+	if err != nil {
+		return fmt.Errorf("failed to list image metadata: %w", err)
+	}
+
+	if wwn, ok := metadata[WWNKey]; !ok || wwn != image.Spec.WWN {
+		if err := rbdImage.SetMetadata(WWNKey, image.Spec.WWN); err != nil {
+			return fmt.Errorf("failed to set wwn (%s): %w", image.Spec.WWN, err)
+		}
+	}
+
+	for limit, value := range image.Spec.Limits {
+		metaKey := fmt.Sprintf("%s%s", LimitMetadataPrefix, limit)
+		metaVal := strconv.FormatInt(value, 10)
+
+		if actualVal, ok := metadata[metaKey]; !ok || actualVal != metaVal {
+			if err := rbdImage.SetMetadata(metaKey, metaVal); err != nil {
+				return fmt.Errorf("failed to set limit (%s): %w", metaKey, err)
+			}
+		}
+	}
+
+	// TODO: Think about caching the ceph auth key instead of re-fetching it on every reconcile loop.
+	user, key, err := fetchAuth(log, r.client, r.conn)
+	if err != nil {
+		return fmt.Errorf("failed to fetch credentials: %w", err)
+	}
+
+	newAccess := &providerapi.ImageAccess{
+		Monitors: r.monitors,
+		Handle:   fmt.Sprintf("%s/%s", r.pool, image.ID),
+		User:     user,
+		UserKey:  key,
+	}
+	newSize := round.OffBytes(image.Spec.Size)
+
+	needsUpdate := image.Status.State != providerapi.ImageStateAvailable ||
+		image.Status.Size != newSize ||
+		!equalAccess(image.Status.Access, newAccess)
+
+	if !needsUpdate {
+		return nil
+	}
+
+	image.Status.State = providerapi.ImageStateAvailable
+	image.Status.Access = newAccess
+	image.Status.Size = newSize
+
+	if _, err = r.imageStore.Update(ctx, image); err != nil {
+		return fmt.Errorf("failed to update image metadata: %w", err)
+	}
+	return nil
+}
+
+func (r *ImageReconciler) createImage(ctx context.Context, ioCtx *rados.IOContext, log logr.Logger, image *providerapi.Image) (bool, error) {
+	options := librbd.NewRbdImageOptions()
+	defer options.Destroy()
+	if err := options.SetString(librbd.ImageOptionDataPool, r.pool); err != nil {
+		return false, fmt.Errorf("failed to set data pool: %w", err)
+	}
+
+	// Create empty image if no snapshot source is given
+	if image.Spec.SnapshotSource == nil {
+		if err := librbd.CreateImage(ioCtx, image.ID, round.OffBytes(image.Spec.Size), options); err != nil {
+			if !errors.Is(err, librbd.ErrExist) {
+				return false, fmt.Errorf("failed to create image: %w", err)
+			}
+			log.V(2).Info("RBD image already exists")
+		} else {
+			log.V(1).Info("Created RBD image")
+		}
+		return true, nil
+	}
+
+	snapshotRef := *image.Spec.SnapshotSource
+	snapshot, err := r.snapshotStore.Get(ctx, snapshotRef)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return false, fmt.Errorf("source snapshot '%s' not found: %w", snapshotRef, err)
+		}
+		return false, fmt.Errorf("failed to get source snapshot: %w", err)
+	}
+
+	if snapshot.Status.Size > int64(image.Spec.Size) {
+		return false, fmt.Errorf("image size is smaller than snapshot size: (%d < %d)", image.Spec.Size, snapshot.Status.Size)
+	}
+
+	switch snapshot.Status.State {
+	case providerapi.SnapshotStatePending:
+		log.V(1).Info("Snapshot is pending, waiting", "snapshotId", snapshot.ID)
+		return false, nil
+	case providerapi.SnapshotStateReady:
+		log.V(2).Info("Source snapshot is available", "snapshotId", snapshot.ID)
+	case providerapi.SnapshotStateFailed:
+		return false, fmt.Errorf("snapshot %s is failed", snapshotRef)
+	default:
+		return false, fmt.Errorf("snapshot %s is in unknown state '%s'", snapshotRef, snapshot.Status.State)
+	}
+
+	parentImage, err := r.imageStore.Get(ctx, snapshot.Spec.ImageRef)
+	if err != nil {
+		return false, fmt.Errorf("failed to get parent image of snapshot %s: %w", snapshot.ID, err)
+	}
+
+	// Put finalizer on source snapshot to allow the image to be flattened before snapshot deletion
+	sourceSnapshotFinalizer := fmt.Sprintf("%s/%s", imageFinalizer, image.ID)
+	if !slices.Contains(snapshot.Finalizers, sourceSnapshotFinalizer) {
+		snapshot.Finalizers = append(snapshot.Finalizers, sourceSnapshotFinalizer)
+		if _, err := r.snapshotStore.Update(ctx, snapshot); err != nil {
+			return false, fmt.Errorf("failed to set finalizers on source snapshot: %w", err)
+		}
+	}
+	log.V(2).Info("Added finalizer to source snapshot", "snapshotId", snapshot.ID)
+
+	if err := librbd.CloneImage(ioCtx, parentImage.ID, snapshot.ID, ioCtx, image.ID, options); err != nil {
+		if !errors.Is(err, librbd.ErrExist) {
+			return false, fmt.Errorf("failed to clone image: %w", err)
+		}
+		log.V(2).Info("RBD clone already exists", "snapshotId", snapshot.ID)
+	} else {
+		log.V(1).Info("Cloned RBD image from snapshot", "snapshotId", snapshot.ID)
+	}
+
+	return true, nil
+}
+
+func (r *ImageReconciler) deleteImage(ctx context.Context, log logr.Logger, image *providerapi.Image) error {
+	if !slices.Contains(image.Finalizers, imageFinalizer) {
+		log.V(2).Info("Image has no finalizer: done")
+		return nil
+	}
+
+	if len(image.Finalizers) > 1 {
+		log.V(2).Info("Image has too many finalizers: waiting")
+		return nil
+	}
+
+	ioCtx, err := r.conn.OpenIOContext(r.pool)
+	if err != nil {
+		return fmt.Errorf("unable to get rados io context: %w", err)
+	}
+	defer ioCtx.Destroy()
+
+	if err := librbd.RemoveImage(ioCtx, image.ID); err != nil && !errors.Is(err, librbd.ErrNotFound) {
+		return fmt.Errorf("failed to remove image %s: %w", image.ID, err)
+	}
+	log.V(1).Info("RBD image removed")
+
+	// Remove finalizer from source snapshot. The RBD child image has been deleted,
+	// so it should not block snapshot deletion anymore
+	if image.Spec.SnapshotSource != nil {
+		snapshot, err := r.snapshotStore.Get(ctx, *image.Spec.SnapshotSource)
+		if err != nil {
+			if !errors.Is(err, store.ErrNotFound) {
+				return fmt.Errorf("failed to get source snapshot from store: %w", err)
+			}
+			log.V(2).Info("Source snapshot already deleted", "snapshotId", *image.Spec.SnapshotSource)
+		} else {
+			sourceSnapshotFinalizer := fmt.Sprintf("%s/%s", imageFinalizer, image.ID)
+			if slices.Contains(snapshot.Finalizers, sourceSnapshotFinalizer) {
+				snapshot.Finalizers = utils.DeleteSliceElement(snapshot.Finalizers, sourceSnapshotFinalizer)
+				if _, err := r.snapshotStore.Update(ctx, snapshot); err != nil {
+					return fmt.Errorf("failed to set finalizers on source snapshot: %w", err)
+				}
+				log.V(2).Info("Removed finalizer from source snapshot", "snapshotId", snapshot.ID)
+			}
+		}
+	}
+
+	image.Finalizers = utils.DeleteSliceElement(image.Finalizers, imageFinalizer)
+	if _, err := r.imageStore.Update(ctx, image); store.IgnoreErrNotFound(err) != nil {
+		return fmt.Errorf("failed to update image metadata: %w", err)
+	}
+	log.V(2).Info("Removed image finalizer")
+	return nil
+}
+
+type fetchAuthResponse struct {
+	Key string `json:"key"`
+}
+
+func fetchAuth(log logr.Logger, client string, conn *rados.Conn) (string, string, error) {
+	cmd, err := json.Marshal(map[string]string{
+		"prefix": "auth get-key",
+		"entity": client,
+		"format": "json",
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("unable to marshal mon command: %w", err)
+	}
+
+	data, _, err := conn.MonCommand(cmd)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to execute mon command: %w", err)
+	}
+
+	response := fetchAuthResponse{}
+	if err := json.Unmarshal(data, &response); err != nil {
+		return "", "", fmt.Errorf("unable to unmarshal mon response: %w", err)
+	}
+
+	return strings.TrimPrefix(client, "client."), response.Key, nil
+}
+
+func equalAccess(a, b *providerapi.ImageAccess) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Monitors == b.Monitors &&
+		a.Handle == b.Handle &&
+		a.User == b.User &&
+		a.UserKey == b.UserKey
+}
+
+func populateImage(ctx context.Context, imageRef string, rbdImage *librbd.Image, bufferSize int64) error {
+	parsed, err := registry.ParseReference(imageRef)
+	if err != nil {
+		return fmt.Errorf("could not parse image reference %q: %w", imageRef, err)
+	}
+
+	dockerStore, err := credentials.NewStoreFromDocker(credentials.StoreOptions{})
+	if err != nil {
+		return fmt.Errorf("could not create credential store: %w", err)
+	}
+
+	client := auth.DefaultClient
+	client.Credential = credentials.Credential(dockerStore)
+	repo := &remote.Repository{
+		Reference: parsed,
+		Client:    client,
+	}
+
+	_, content, err := repo.Blobs().FetchReference(ctx, parsed.Reference)
+	if err != nil {
+		return fmt.Errorf("could not fetch blob %q: %w", imageRef, err)
+	}
+	throughputReader := rater.NewRater(content)
+	buffer := make([]byte, bufferSize)
+	if _, err := io.CopyBuffer(rbdImage, throughputReader, buffer); err != nil {
+		return fmt.Errorf("failed to copy image contents onto RBD image: %w", err)
+	}
+
+	return nil
+}

--- a/internal/controllers/v2/image_controller.go
+++ b/internal/controllers/v2/image_controller.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ironcore-dev/ceph-provider/internal/encryption"
 	"github.com/ironcore-dev/ceph-provider/internal/rater"
 	"github.com/ironcore-dev/ceph-provider/internal/round"
-	"github.com/ironcore-dev/ceph-provider/internal/utils"
 	"github.com/ironcore-dev/provider-utils/eventutils/event"
 	"github.com/ironcore-dev/provider-utils/storeutils/store"
 	"k8s.io/client-go/util/workqueue"
@@ -242,8 +241,7 @@ func (r *ImageReconciler) reconcileImage(ctx context.Context, id string) error {
 	}
 
 	if !slices.Contains(image.Finalizers, imageFinalizer) {
-		image.Finalizers = append(image.Finalizers, imageFinalizer)
-		if _, err := r.imageStore.Update(ctx, image); err != nil {
+		if _, err := addFinalizer(ctx, r.imageStore, image, imageFinalizer); err != nil {
 			return fmt.Errorf("failed to set finalizers: %w", err)
 		}
 		return nil
@@ -309,13 +307,10 @@ func (r *ImageReconciler) reconcileImage(ctx context.Context, id string) error {
 			// so the image is no longer connected to the snapshot
 			if snapshot != nil {
 				sourceSnapshotFinalizer := fmt.Sprintf("%s/%s", imageFinalizer, image.ID)
-				if slices.Contains(snapshot.Finalizers, sourceSnapshotFinalizer) {
-					snapshot.Finalizers = utils.DeleteSliceElement(snapshot.Finalizers, sourceSnapshotFinalizer)
-					if _, err := r.snapshotStore.Update(ctx, snapshot); err != nil {
-						return fmt.Errorf("failed to set finalizers on source snapshot: %w", err)
-					}
-					log.V(2).Info("Removed finalizer from source snapshot", "snapshotId", snapshot.ID)
+				if _, err := removeFinalizer(ctx, r.snapshotStore, snapshot, sourceSnapshotFinalizer); err != nil {
+					return fmt.Errorf("failed to remove finalizer from source snapshot: %w", err)
 				}
+				log.V(2).Info("Removed finalizer from source snapshot", "snapshotId", snapshot.ID)
 			}
 		}
 	} else {
@@ -375,7 +370,7 @@ func (r *ImageReconciler) reconcileImage(ctx context.Context, id string) error {
 	}
 
 	// TODO: Think about caching the ceph auth key instead of re-fetching it on every reconcile loop.
-	user, key, err := fetchAuth(log, r.client, r.conn)
+	user, key, err := fetchAuth(r.client, r.conn)
 	if err != nil {
 		return fmt.Errorf("failed to fetch credentials: %w", err)
 	}
@@ -458,11 +453,8 @@ func (r *ImageReconciler) createImage(ctx context.Context, ioCtx *rados.IOContex
 
 	// Put finalizer on source snapshot to allow the image to be flattened before snapshot deletion
 	sourceSnapshotFinalizer := fmt.Sprintf("%s/%s", imageFinalizer, image.ID)
-	if !slices.Contains(snapshot.Finalizers, sourceSnapshotFinalizer) {
-		snapshot.Finalizers = append(snapshot.Finalizers, sourceSnapshotFinalizer)
-		if _, err := r.snapshotStore.Update(ctx, snapshot); err != nil {
-			return false, fmt.Errorf("failed to set finalizers on source snapshot: %w", err)
-		}
+	if snapshot, err = addFinalizer(ctx, r.snapshotStore, snapshot, sourceSnapshotFinalizer); err != nil {
+		return false, fmt.Errorf("failed to set finalizers on source snapshot: %w", err)
 	}
 	log.V(2).Info("Added finalizer to source snapshot", "snapshotId", snapshot.ID)
 
@@ -511,18 +503,14 @@ func (r *ImageReconciler) deleteImage(ctx context.Context, log logr.Logger, imag
 			log.V(2).Info("Source snapshot already deleted", "snapshotId", *image.Spec.SnapshotSource)
 		} else {
 			sourceSnapshotFinalizer := fmt.Sprintf("%s/%s", imageFinalizer, image.ID)
-			if slices.Contains(snapshot.Finalizers, sourceSnapshotFinalizer) {
-				snapshot.Finalizers = utils.DeleteSliceElement(snapshot.Finalizers, sourceSnapshotFinalizer)
-				if _, err := r.snapshotStore.Update(ctx, snapshot); err != nil {
-					return fmt.Errorf("failed to set finalizers on source snapshot: %w", err)
-				}
-				log.V(2).Info("Removed finalizer from source snapshot", "snapshotId", snapshot.ID)
+			if _, err := removeFinalizer(ctx, r.snapshotStore, snapshot, sourceSnapshotFinalizer); err != nil {
+				return fmt.Errorf("failed to remove finalizer from source snapshot: %w", err)
 			}
+			log.V(2).Info("Removed finalizer from source snapshot", "snapshotId", snapshot.ID)
 		}
 	}
 
-	image.Finalizers = utils.DeleteSliceElement(image.Finalizers, imageFinalizer)
-	if _, err := r.imageStore.Update(ctx, image); store.IgnoreErrNotFound(err) != nil {
+	if _, err := removeFinalizer(ctx, r.imageStore, image, imageFinalizer); store.IgnoreErrNotFound(err) != nil {
 		return fmt.Errorf("failed to update image metadata: %w", err)
 	}
 	log.V(2).Info("Removed image finalizer")
@@ -533,7 +521,7 @@ type fetchAuthResponse struct {
 	Key string `json:"key"`
 }
 
-func fetchAuth(log logr.Logger, client string, conn *rados.Conn) (string, string, error) {
+func fetchAuth(client string, conn *rados.Conn) (string, string, error) {
 	cmd, err := json.Marshal(map[string]string{
 		"prefix": "auth get-key",
 		"entity": client,

--- a/internal/controllers/v2/snapshot_controller.go
+++ b/internal/controllers/v2/snapshot_controller.go
@@ -14,7 +14,6 @@ import (
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/go-logr/logr"
 	providerapi "github.com/ironcore-dev/ceph-provider/api/v2"
-	"github.com/ironcore-dev/ceph-provider/internal/utils"
 	"github.com/ironcore-dev/provider-utils/eventutils/event"
 	"github.com/ironcore-dev/provider-utils/storeutils/store"
 	"k8s.io/client-go/util/workqueue"
@@ -196,8 +195,7 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 	}
 
 	if !slices.Contains(snapshot.Finalizers, snapshotFinalizer) {
-		snapshot.Finalizers = append(snapshot.Finalizers, snapshotFinalizer)
-		if _, err := r.snapshotStore.Update(ctx, snapshot); err != nil {
+		if _, err := addFinalizer(ctx, r.snapshotStore, snapshot, snapshotFinalizer); err != nil {
 			return fmt.Errorf("failed to set finalizers: %w", err)
 		}
 		return nil
@@ -221,11 +219,8 @@ func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) e
 
 	// Put finalizer on parent image to block image deletion until all snapshots have been deleted
 	parentImageFinalizer := fmt.Sprintf("%s/%s", snapshotFinalizer, snapshot.ID)
-	if !slices.Contains(parentImage.Finalizers, parentImageFinalizer) {
-		parentImage.Finalizers = append(parentImage.Finalizers, parentImageFinalizer)
-		if _, err := r.imageStore.Update(ctx, parentImage); err != nil {
-			return fmt.Errorf("failed to set finalizers on parent image: %w", err)
-		}
+	if parentImage, err = addFinalizer(ctx, r.imageStore, parentImage, parentImageFinalizer); err != nil {
+		return fmt.Errorf("failed to set finalizers on parent image: %w", err)
 	}
 	log.V(2).Info("Added finalizer to parent image", "parentImageId", parentImage.ID)
 
@@ -366,17 +361,13 @@ func (r *SnapshotReconciler) deleteSnapshot(ctx context.Context, log logr.Logger
 	} else {
 		// Remove finalizer from parent image to signal this snapshot is no longer blocking deletion
 		parentImageFinalizer := fmt.Sprintf("%s/%s", snapshotFinalizer, snapshot.ID)
-		if slices.Contains(parentImage.Finalizers, parentImageFinalizer) {
-			parentImage.Finalizers = utils.DeleteSliceElement(parentImage.Finalizers, parentImageFinalizer)
-			if _, err := r.imageStore.Update(ctx, parentImage); err != nil {
-				return fmt.Errorf("failed to set finalizers on parent image: %w", err)
-			}
-			log.V(2).Info("Removed finalizer from parent image", "parentImageId", parentImage.ID)
+		if _, err := removeFinalizer(ctx, r.imageStore, parentImage, parentImageFinalizer); err != nil {
+			return fmt.Errorf("failed to remove finalizer from parent image: %w", err)
 		}
+		log.V(2).Info("Removed finalizer from parent image", "parentImageId", parentImage.ID)
 	}
 
-	snapshot.Finalizers = utils.DeleteSliceElement(snapshot.Finalizers, snapshotFinalizer)
-	if _, err := r.snapshotStore.Update(ctx, snapshot); store.IgnoreErrNotFound(err) != nil {
+	if _, err := removeFinalizer(ctx, r.snapshotStore, snapshot, snapshotFinalizer); store.IgnoreErrNotFound(err) != nil {
 		return fmt.Errorf("failed to update snapshot metadata: %w", err)
 	}
 	log.V(2).Info("Removed snapshot finalizer")

--- a/internal/controllers/v2/snapshot_controller.go
+++ b/internal/controllers/v2/snapshot_controller.go
@@ -1,0 +1,384 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/ceph/go-ceph/rados"
+	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/go-logr/logr"
+	providerapi "github.com/ironcore-dev/ceph-provider/api/v2"
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	"github.com/ironcore-dev/provider-utils/eventutils/event"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type SnapshotReconcilerOptions struct {
+	Pool       string
+	WorkerSize int
+}
+
+func NewSnapshotReconciler(
+	log logr.Logger,
+	conn *rados.Conn,
+	snapshotStore store.Store[*providerapi.Snapshot],
+	imageStore store.Store[*providerapi.Image],
+	snapshotEvents event.Source[*providerapi.Snapshot],
+	imageEvents event.Source[*providerapi.Image],
+	opts SnapshotReconcilerOptions,
+) (*SnapshotReconciler, error) {
+	if conn == nil {
+		return nil, fmt.Errorf("must specify conn")
+	}
+
+	if snapshotStore == nil {
+		return nil, fmt.Errorf("must specify snapshot store")
+	}
+
+	if imageStore == nil {
+		return nil, fmt.Errorf("must specify image store")
+	}
+
+	if snapshotEvents == nil {
+		return nil, fmt.Errorf("must specify snapshot events")
+	}
+
+	if imageEvents == nil {
+		return nil, fmt.Errorf("must specify image events")
+	}
+
+	if opts.Pool == "" {
+		return nil, fmt.Errorf("must specify pool")
+	}
+
+	if opts.WorkerSize == 0 {
+		opts.WorkerSize = 15
+	}
+
+	return &SnapshotReconciler{
+		log:            log,
+		conn:           conn,
+		queue:          workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]()),
+		snapshotStore:  snapshotStore,
+		imageStore:     imageStore,
+		snapshotEvents: snapshotEvents,
+		imageEvents:    imageEvents,
+		pool:           opts.Pool,
+		workerSize:     opts.WorkerSize,
+	}, nil
+}
+
+type SnapshotReconciler struct {
+	log  logr.Logger
+	conn *rados.Conn
+
+	queue workqueue.TypedRateLimitingInterface[string]
+
+	snapshotStore store.Store[*providerapi.Snapshot]
+	imageStore    store.Store[*providerapi.Image]
+
+	snapshotEvents event.Source[*providerapi.Snapshot]
+	imageEvents    event.Source[*providerapi.Image]
+
+	pool string
+
+	workerSize int
+}
+
+func (r *SnapshotReconciler) Start(ctx context.Context) error {
+	log := r.log
+
+	snapEventReg, err := r.snapshotEvents.AddHandler(event.HandlerFunc[*providerapi.Snapshot](func(evt event.Event[*providerapi.Snapshot]) {
+		r.queue.Add(evt.Object.ID)
+	}))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = r.snapshotEvents.RemoveHandler(snapEventReg)
+	}()
+
+	imageEventReg, err := r.imageEvents.AddHandler(event.HandlerFunc[*providerapi.Image](func(evt event.Event[*providerapi.Image]) {
+		if evt.Type != event.TypeUpdated && evt.Type != event.TypeDeleted {
+			return
+		}
+		if evt.Object.Status.State != providerapi.ImageStateAvailable &&
+			evt.Object.DeletedAt == nil {
+			return
+		}
+		r.requeueSnapshotsForImage(ctx, evt.Object.ID)
+	}))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = r.imageEvents.RemoveHandler(imageEventReg)
+	}()
+
+	go func() {
+		<-ctx.Done()
+		r.queue.ShutDown()
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < r.workerSize; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for r.processNextWorkItem(ctx, log) {
+			}
+		}()
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func (r *SnapshotReconciler) requeueSnapshotsForImage(ctx context.Context, imageID string) {
+	snapshots, err := r.snapshotStore.List(ctx, store.MatchingFields{providerapi.SnapshotSpecImageRefField: imageID})
+	if err != nil {
+		r.log.Error(err, "failed to list snapshots for image event requeue")
+		return
+	}
+	for _, snap := range snapshots {
+		r.queue.Add(snap.ID)
+	}
+}
+
+func (r *SnapshotReconciler) processNextWorkItem(ctx context.Context, log logr.Logger) bool {
+	id, shutdown := r.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer r.queue.Done(id)
+
+	log = log.WithValues("snapshotId", id)
+	ctx = logr.NewContext(ctx, log)
+
+	if err := r.reconcileSnapshot(ctx, id); err != nil {
+		log.Error(err, "failed to reconcile snapshot")
+		r.queue.AddRateLimited(id)
+		return true
+	}
+
+	r.queue.Forget(id)
+	return true
+}
+
+const (
+	snapshotFinalizer = "snapshot"
+)
+
+func (r *SnapshotReconciler) reconcileSnapshot(ctx context.Context, id string) error {
+	log := logr.FromContextOrDiscard(ctx)
+
+	log.V(2).Info("Get snapshot from store")
+	snapshot, err := r.snapshotStore.Get(ctx, id)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("failed to fetch snapshot from store: %w", err)
+		}
+		return nil
+	}
+
+	if snapshot.DeletedAt != nil {
+		if err := r.deleteSnapshot(ctx, log, snapshot); err != nil {
+			return fmt.Errorf("failed to delete snapshot: %w", err)
+		}
+		return nil
+	}
+
+	if !slices.Contains(snapshot.Finalizers, snapshotFinalizer) {
+		snapshot.Finalizers = append(snapshot.Finalizers, snapshotFinalizer)
+		if _, err := r.snapshotStore.Update(ctx, snapshot); err != nil {
+			return fmt.Errorf("failed to set finalizers: %w", err)
+		}
+		return nil
+	}
+
+	if snapshot.Status.State == providerapi.SnapshotStateFailed {
+		log.V(2).Info("Snapshot is in failed state, not reconciling")
+		return nil
+	}
+
+	// Verify parent image exists and is available
+	parentImage, err := r.imageStore.Get(ctx, snapshot.Spec.ImageRef)
+	if err != nil {
+		return fmt.Errorf("failed to get parent image %s: %w", snapshot.Spec.ImageRef, err)
+	}
+
+	if parentImage.Status.State != providerapi.ImageStateAvailable {
+		log.V(1).Info("Parent image not yet available, waiting", "imageRef", snapshot.Spec.ImageRef)
+		return nil
+	}
+
+	// Put finalizer on parent image to block image deletion until all snapshots have been deleted
+	parentImageFinalizer := fmt.Sprintf("%s/%s", snapshotFinalizer, snapshot.ID)
+	if !slices.Contains(parentImage.Finalizers, parentImageFinalizer) {
+		parentImage.Finalizers = append(parentImage.Finalizers, parentImageFinalizer)
+		if _, err := r.imageStore.Update(ctx, parentImage); err != nil {
+			return fmt.Errorf("failed to set finalizers on parent image: %w", err)
+		}
+	}
+	log.V(2).Info("Added finalizer to parent image", "parentImageId", parentImage.ID)
+
+	ioCtx, err := r.conn.OpenIOContext(r.pool)
+	if err != nil {
+		return fmt.Errorf("unable to get rados io context: %w", err)
+	}
+	defer ioCtx.Destroy()
+
+	rbdParentImage, err := librbd.OpenImage(ioCtx, parentImage.ID, snapshot.ID)
+	if err != nil {
+		if !errors.Is(err, librbd.ErrNotFound) {
+			return fmt.Errorf("failed to open parent RBD image: %w", err)
+		}
+		log.V(2).Info("RBD snapshot not found, creating")
+		if ok, err := r.createSnapshot(ctx, ioCtx, log, parentImage, snapshot); err != nil {
+			return fmt.Errorf("failed to create snapshot: %w", err)
+		} else if !ok {
+			return nil
+		}
+		rbdParentImage, err = librbd.OpenImage(ioCtx, parentImage.ID, snapshot.ID)
+		if err != nil {
+			return fmt.Errorf("failed to open parent RBD image after snapshot creation: %w", err)
+		}
+	}
+	defer closeImage(log, rbdParentImage)
+
+	rbdSnapshot := rbdParentImage.GetSnapshot(snapshot.ID)
+	isProtected, err := rbdSnapshot.IsProtected()
+	if err != nil {
+		return fmt.Errorf("failed to check snapshot protection: %w", err)
+	}
+	switch {
+	case snapshot.Spec.Protection == providerapi.SnapshotProtectionNone && isProtected:
+		if err := rbdSnapshot.Unprotect(); err != nil {
+			return fmt.Errorf("failed to unprotect snapshot: %w", err)
+		}
+		log.V(1).Info("RBD snapshot unprotected")
+	case snapshot.Spec.Protection == providerapi.SnapshotProtectionProtected && !isProtected:
+		if err := rbdSnapshot.Protect(); err != nil {
+			return fmt.Errorf("failed to protect snapshot: %w", err)
+		}
+		log.V(1).Info("RBD snapshot protected")
+	}
+
+	// Set the newly created snapshot as source of readable data for the image handle (relevant for size and digest)
+	if err := rbdParentImage.SetSnapshot(snapshot.ID); err != nil {
+		return fmt.Errorf("failed to set snapshot %s: %w", snapshot.ID, err)
+	}
+	snapSize, err := rbdParentImage.GetSize()
+	if err != nil {
+		return fmt.Errorf("failed to get snapshot size: %w", err)
+	}
+
+	snapshot.Status.State = providerapi.SnapshotStateReady
+	snapshot.Status.Size = int64(snapSize)
+	if _, err := r.snapshotStore.Update(ctx, snapshot); err != nil {
+		return fmt.Errorf("failed to update snapshot status: %w", err)
+	}
+
+	return nil
+}
+
+func (r *SnapshotReconciler) createSnapshot(ctx context.Context, ioCtx *rados.IOContext, log logr.Logger, parentImage *providerapi.Image, snapshot *providerapi.Snapshot) (bool, error) {
+	rbdParentImage, err := librbd.OpenImage(ioCtx, parentImage.ID, librbd.NoSnapshot)
+	if err != nil {
+		return false, fmt.Errorf("failed to open parent image: %w", err)
+	}
+	defer closeImage(log, rbdParentImage)
+
+	if _, err := rbdParentImage.CreateSnapshot(snapshot.ID); err != nil {
+		if !errors.Is(err, librbd.ErrExist) {
+			// If there is an RBD error during the snapshot creation, do not treat it as an error and keep reconciling the snapshot until creation succeeds.
+			// Instead, log the error, mark the snapshot as failed and stop the reconcile.
+			log.V(1).Info("RBD snapshot creation failed", "rbdError", err.Error(), "parentImageId", parentImage.ID)
+			snapshot.Status.State = providerapi.SnapshotStateFailed
+			if _, err := r.snapshotStore.Update(ctx, snapshot); err != nil {
+				return false, fmt.Errorf("failed to update snapshot status: %w", err)
+			}
+			log.V(1).Info("Set snapshot state to failed")
+			return false, nil
+		}
+		log.V(2).Info("RBD snapshot already exists", "parentImageId", parentImage.ID)
+	} else {
+		log.V(1).Info("Created RBD snapshot", "parentImageId", parentImage.ID)
+	}
+	return true, nil
+}
+func (r *SnapshotReconciler) deleteSnapshot(ctx context.Context, log logr.Logger, snapshot *providerapi.Snapshot) error {
+	if !slices.Contains(snapshot.Finalizers, snapshotFinalizer) {
+		log.V(2).Info("Snapshot has no finalizer: done")
+		return nil
+	}
+
+	if len(snapshot.Finalizers) > 1 {
+		log.V(2).Info("Snapshot has too many finalizers: waiting")
+		return nil
+	}
+
+	ioCtx, err := r.conn.OpenIOContext(r.pool)
+	if err != nil {
+		return fmt.Errorf("unable to get rados io context: %w", err)
+	}
+	defer ioCtx.Destroy()
+
+	rbdImage, err := librbd.OpenImage(ioCtx, snapshot.Spec.ImageRef, snapshot.ID)
+	if err != nil {
+		if !errors.Is(err, librbd.ErrNotFound) {
+			return fmt.Errorf("failed to open parent RBD image: %w", err)
+		}
+		log.V(2).Info("RBD snapshot already removed")
+	} else {
+		defer closeImage(log, rbdImage)
+
+		rbdSnapshot := rbdImage.GetSnapshot(snapshot.ID)
+
+		if protected, err := rbdSnapshot.IsProtected(); err != nil {
+			return fmt.Errorf("failed to check if RBD snapshot is protected: %w", err)
+		} else if protected {
+			if err := rbdSnapshot.Unprotect(); err != nil {
+				return fmt.Errorf("failed to unprotect RBD snapshot: %w", err)
+			}
+			log.V(2).Info("RBD snapshot unprotected before deletion")
+		}
+
+		if err := rbdSnapshot.Remove(); err != nil && !errors.Is(err, librbd.ErrNotFound) {
+			return fmt.Errorf("failed to remove snapshot: %w", err)
+		}
+		log.V(1).Info("Snapshot removed")
+	}
+
+	parentImage, err := r.imageStore.Get(ctx, snapshot.Spec.ImageRef)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("failed to get parent image %s: %w", snapshot.Spec.ImageRef, err)
+		}
+		log.V(2).Info("parent image already removed")
+	} else {
+		// Remove finalizer from parent image to signal this snapshot is no longer blocking deletion
+		parentImageFinalizer := fmt.Sprintf("%s/%s", snapshotFinalizer, snapshot.ID)
+		if slices.Contains(parentImage.Finalizers, parentImageFinalizer) {
+			parentImage.Finalizers = utils.DeleteSliceElement(parentImage.Finalizers, parentImageFinalizer)
+			if _, err := r.imageStore.Update(ctx, parentImage); err != nil {
+				return fmt.Errorf("failed to set finalizers on parent image: %w", err)
+			}
+			log.V(2).Info("Removed finalizer from parent image", "parentImageId", parentImage.ID)
+		}
+	}
+
+	snapshot.Finalizers = utils.DeleteSliceElement(snapshot.Finalizers, snapshotFinalizer)
+	if _, err := r.snapshotStore.Update(ctx, snapshot); store.IgnoreErrNotFound(err) != nil {
+		return fmt.Errorf("failed to update snapshot metadata: %w", err)
+	}
+	log.V(2).Info("Removed snapshot finalizer")
+	return nil
+}

--- a/internal/controllers/v2/volume_controller.go
+++ b/internal/controllers/v2/volume_controller.go
@@ -13,7 +13,6 @@ import (
 	"github.com/distribution/reference"
 	"github.com/go-logr/logr"
 	providerapi "github.com/ironcore-dev/ceph-provider/api/v2"
-	"github.com/ironcore-dev/ceph-provider/internal/utils"
 	ironcoreimage "github.com/ironcore-dev/ironcore-image"
 	"github.com/ironcore-dev/ironcore-image/oci/image"
 	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
@@ -233,8 +232,8 @@ func (r *VolumeReconciler) reconcileVolume(ctx context.Context, id string) error
 	}
 
 	if !slices.Contains(volume.Finalizers, VolumeFinalizer) {
-		volume.Finalizers = append(volume.Finalizers, VolumeFinalizer)
-		if _, err := r.volumeStore.Update(ctx, volume); err != nil {
+		var err error
+		if _, err = addFinalizer(ctx, r.volumeStore, volume, VolumeFinalizer); err != nil {
 			return fmt.Errorf("failed to set finalizers: %w", err)
 		}
 		return nil
@@ -319,13 +318,21 @@ func (r *VolumeReconciler) reconcileVolume(ctx context.Context, id string) error
 	}
 }
 
-func (r *VolumeReconciler) reconcileEmptyVolume(ctx context.Context, log logr.Logger, volume *providerapi.Volume) error {
-	log.V(2).Info("Reconciling empty volume")
+func (r *VolumeReconciler) setVolumeImageRef(ctx context.Context, volume *providerapi.Volume, imageID string) error {
+	if volume.Status.ImageRef == imageID {
+		return nil
+	}
+	volume.Status.ImageRef = imageID
+	if _, err := r.volumeStore.Update(ctx, volume); err != nil {
+		return fmt.Errorf("failed to update volume with image ref: %w", err)
+	}
+	return nil
+}
 
-	imageID := VolumeImageIDPrefix + volume.ID
-	img := &providerapi.Image{
+func buildVolumeImage(volume *providerapi.Volume, snapshotSource *string) *providerapi.Image {
+	return &providerapi.Image{
 		Metadata: apiutils.Metadata{
-			ID: imageID,
+			ID: VolumeImageIDPrefix + volume.ID,
 		},
 		Spec: providerapi.ImageSpec{
 			Size:   volume.Spec.Size,
@@ -335,32 +342,22 @@ func (r *VolumeReconciler) reconcileEmptyVolume(ctx context.Context, log logr.Lo
 				Type:                providerapi.EncryptionType(volume.Spec.VolumeEncryption.Type),
 				EncryptedPassphrase: volume.Spec.VolumeEncryption.EncryptedPassphrase,
 			},
-			SnapshotSource: nil,
+			SnapshotSource: snapshotSource,
 		},
 	}
+}
 
-	createdImage, err := r.imageStore.Create(ctx, img)
+func (r *VolumeReconciler) reconcileEmptyVolume(ctx context.Context, log logr.Logger, volume *providerapi.Volume) error {
+	log.V(2).Info("Reconciling empty volume")
+
+	img := buildVolumeImage(volume, nil)
+
+	createdImage, err := createOrGet(ctx, log, r.imageStore, img, "Image created", "Image already exists")
 	if err != nil {
-		if !errors.Is(err, store.ErrAlreadyExists) {
-			return fmt.Errorf("failed to create image: %w", err)
-		}
-		log.V(2).Info("Image already exists", "imageId", imageID)
-		createdImage, err = r.imageStore.Get(ctx, imageID)
-		if err != nil {
-			return fmt.Errorf("failed to get created image: %w", err)
-		}
-	} else {
-		log.V(1).Info("Image created", "imageId", createdImage.ID)
+		return fmt.Errorf("failed to create or get image: %w", err)
 	}
 
-	if volume.Status.ImageRef != createdImage.ID {
-		volume.Status.ImageRef = createdImage.ID
-		if _, err := r.volumeStore.Update(ctx, volume); err != nil {
-			return fmt.Errorf("failed to update volume with image ref: %w", err)
-		}
-	}
-
-	return nil
+	return r.setVolumeImageRef(ctx, volume, createdImage.ID)
 }
 
 func (r *VolumeReconciler) reconcileOSVolume(ctx context.Context, log logr.Logger, volume *providerapi.Volume) error {
@@ -431,16 +428,9 @@ func (r *VolumeReconciler) reconcileOSVolume(ctx context.Context, log logr.Logge
 			},
 		}
 
-		baseImage, err = r.imageStore.Create(ctx, baseImage)
+		baseImage, err = createOrGet(ctx, log, r.imageStore, baseImage, "Base image created", "Base image already exists, fetching")
 		if err != nil {
-			if !errors.Is(err, store.ErrAlreadyExists) {
-				return fmt.Errorf("failed to create base image: %w", err)
-			}
-			log.V(1).Info("Base image already exists, fetching", "baseImageId", baseImageID)
-			baseImage, err = r.imageStore.Get(ctx, baseImageID)
-			if err != nil {
-				return fmt.Errorf("failed to get existing base image: %w", err)
-			}
+			return fmt.Errorf("failed to create or get base image: %w", err)
 		}
 	}
 
@@ -474,16 +464,9 @@ func (r *VolumeReconciler) reconcileOSVolume(ctx context.Context, log logr.Logge
 			},
 		}
 
-		snapshot, err = r.snapshotStore.Create(ctx, snapshot)
+		snapshot, err = createOrGet(ctx, log, r.snapshotStore, snapshot, "Snapshot created", "Snapshot already exists, fetching")
 		if err != nil {
-			if !errors.Is(err, store.ErrAlreadyExists) {
-				return fmt.Errorf("failed to create snapshot: %w", err)
-			}
-			log.V(1).Info("Snapshot already exists, fetching", "snapshotId", snapshotID)
-			snapshot, err = r.snapshotStore.Get(ctx, snapshotID)
-			if err != nil {
-				return fmt.Errorf("failed to get existing snapshot: %w", err)
-			}
+			return fmt.Errorf("failed to create or get snapshot: %w", err)
 		}
 	}
 
@@ -508,47 +491,16 @@ func (r *VolumeReconciler) reconcileOSVolume(ctx context.Context, log logr.Logge
 	}
 
 	// Step 6: Create volume's image as clone from snapshot
-	volumeImageID := VolumeImageIDPrefix + volume.ID
-	log.V(1).Info("Creating volume image from snapshot", "snapshotId", snapshotID, "imageId", volumeImageID)
-	volumeImage := &providerapi.Image{
-		Metadata: apiutils.Metadata{
-			ID: volumeImageID,
-		},
-		Spec: providerapi.ImageSpec{
-			Size:   volume.Spec.Size,
-			WWN:    volume.Spec.WWN,
-			Limits: volume.Spec.Limits,
-			Encryption: providerapi.EncryptionSpec{
-				Type:                providerapi.EncryptionType(volume.Spec.VolumeEncryption.Type),
-				EncryptedPassphrase: volume.Spec.VolumeEncryption.EncryptedPassphrase,
-			},
-			SnapshotSource: &snapshotID,
-		},
-	}
+	volumeImage := buildVolumeImage(volume, &snapshotID)
+	log.V(1).Info("Creating volume image from snapshot", "snapshotId", snapshotID, "imageId", volumeImage.ID)
 
-	createdImage, err := r.imageStore.Create(ctx, volumeImage)
+	createdImage, err := createOrGet(ctx, log, r.imageStore, volumeImage, "Volume image created", "Volume image already exists")
 	if err != nil {
-		if !errors.Is(err, store.ErrAlreadyExists) {
-			return fmt.Errorf("failed to create volume image: %w", err)
-		}
-		log.V(2).Info("Volume image already exists", "imageId", volumeImageID, "snapshotId", snapshotID)
-		createdImage, err = r.imageStore.Get(ctx, volumeImageID)
-		if err != nil {
-			return fmt.Errorf("failed to get created image: %w", err)
-		}
-	} else {
-		log.V(1).Info("Volume image created", "imageId", createdImage.ID, "snapshotId", snapshotID)
+		return fmt.Errorf("failed to create or get volume image: %w", err)
 	}
 
 	// Step 7: Update volume status with ImageRef
-	if volume.Status.ImageRef != createdImage.ID {
-		volume.Status.ImageRef = createdImage.ID
-		if _, err := r.volumeStore.Update(ctx, volume); err != nil {
-			return fmt.Errorf("failed to update volume with image ref: %w", err)
-		}
-	}
-
-	return nil
+	return r.setVolumeImageRef(ctx, volume, createdImage.ID)
 }
 
 func (r *VolumeReconciler) reconcileRestoredVolume(ctx context.Context, log logr.Logger, volume *providerapi.Volume) error {
@@ -577,47 +529,17 @@ func (r *VolumeReconciler) reconcileRestoredVolume(ctx context.Context, log logr
 	}
 
 	// Create new Image from snapshot
-	imageID := VolumeImageIDPrefix + volume.ID
+	img := buildVolumeImage(volume, &snapshotID)
+	imageID := img.ID
 	log.V(1).Info("Creating image from snapshot", "snapshotId", snapshotID, "imageId", imageID)
-	img := &providerapi.Image{
-		Metadata: apiutils.Metadata{
-			ID: imageID,
-		},
-		Spec: providerapi.ImageSpec{
-			Size:   volume.Spec.Size,
-			WWN:    volume.Spec.WWN,
-			Limits: volume.Spec.Limits,
-			Encryption: providerapi.EncryptionSpec{
-				Type:                providerapi.EncryptionType(volume.Spec.VolumeEncryption.Type),
-				EncryptedPassphrase: volume.Spec.VolumeEncryption.EncryptedPassphrase,
-			},
-			SnapshotSource: &snapshotID,
-		},
-	}
 
-	createdImage, err := r.imageStore.Create(ctx, img)
+	createdImage, err := createOrGet(ctx, log, r.imageStore, img, "Image created from snapshot", "Image already exists")
 	if err != nil {
-		if !errors.Is(err, store.ErrAlreadyExists) {
-			return fmt.Errorf("failed to create image: %w", err)
-		}
-		log.V(2).Info("Image already exists", "imageId", imageID, "snapshotId", snapshotID)
-		createdImage, err = r.imageStore.Get(ctx, imageID)
-		if err != nil {
-			return fmt.Errorf("failed to get created image: %w", err)
-		}
-	} else {
-		log.V(1).Info("Image created from snapshot", "ImageId", createdImage.ID, "SnapshotId", snapshotID)
+		return fmt.Errorf("failed to create or get image: %w", err)
 	}
 
 	// Update volume status with ImageRef
-	if volume.Status.ImageRef != createdImage.ID {
-		volume.Status.ImageRef = createdImage.ID
-		if _, err := r.volumeStore.Update(ctx, volume); err != nil {
-			return fmt.Errorf("failed to update volume with image ref: %w", err)
-		}
-	}
-
-	return nil
+	return r.setVolumeImageRef(ctx, volume, createdImage.ID)
 }
 
 func (r *VolumeReconciler) deleteVolume(ctx context.Context, log logr.Logger, volume *providerapi.Volume) error {
@@ -643,8 +565,7 @@ func (r *VolumeReconciler) deleteVolume(ctx context.Context, log logr.Logger, vo
 	// as they may be shared by multiple volumes (golden image pattern).
 	// Clean up of unused base images and snapshots can be added later.
 
-	volume.Finalizers = utils.DeleteSliceElement(volume.Finalizers, VolumeFinalizer)
-	if _, err := r.volumeStore.Update(ctx, volume); store.IgnoreErrNotFound(err) != nil {
+	if _, err := removeFinalizer(ctx, r.volumeStore, volume, VolumeFinalizer); store.IgnoreErrNotFound(err) != nil {
 		return fmt.Errorf("failed to update volume metadata: %w", err)
 	}
 	log.V(2).Info("Removed volume finalizer")

--- a/internal/controllers/v2/volume_controller.go
+++ b/internal/controllers/v2/volume_controller.go
@@ -1,0 +1,662 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/distribution/reference"
+	"github.com/go-logr/logr"
+	providerapi "github.com/ironcore-dev/ceph-provider/api/v2"
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	ironcoreimage "github.com/ironcore-dev/ironcore-image"
+	"github.com/ironcore-dev/ironcore-image/oci/image"
+	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
+	"github.com/ironcore-dev/provider-utils/eventutils/event"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type VolumeReconcilerOptions struct {
+	WorkerSize int
+}
+
+func NewVolumeReconciler(
+	log logr.Logger,
+	registry image.Source,
+	snapshotStore store.Store[*providerapi.Snapshot],
+	imageStore store.Store[*providerapi.Image],
+	volumeStore store.Store[*providerapi.Volume],
+	events event.Source[*providerapi.Volume],
+	imageEvents event.Source[*providerapi.Image],
+	snapshotEvents event.Source[*providerapi.Snapshot],
+	opts VolumeReconcilerOptions,
+) (*VolumeReconciler, error) {
+	if registry == nil {
+		return nil, fmt.Errorf("must specify registry")
+	}
+
+	if snapshotStore == nil {
+		return nil, fmt.Errorf("must specify snapshot store")
+	}
+
+	if imageStore == nil {
+		return nil, fmt.Errorf("must specify image store")
+	}
+
+	if volumeStore == nil {
+		return nil, fmt.Errorf("must specify volume store")
+	}
+
+	if events == nil {
+		return nil, fmt.Errorf("must specify events")
+	}
+
+	if imageEvents == nil {
+		return nil, fmt.Errorf("must specify image events")
+	}
+
+	if snapshotEvents == nil {
+		return nil, fmt.Errorf("must specify snapshot events")
+	}
+
+	if opts.WorkerSize == 0 {
+		opts.WorkerSize = 15
+	}
+
+	return &VolumeReconciler{
+		log:            log,
+		registry:       registry,
+		queue:          workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]()),
+		snapshotStore:  snapshotStore,
+		imageStore:     imageStore,
+		volumeStore:    volumeStore,
+		events:         events,
+		imageEvents:    imageEvents,
+		snapshotEvents: snapshotEvents,
+		workerSize:     opts.WorkerSize,
+	}, nil
+}
+
+type VolumeReconciler struct {
+	log logr.Logger
+
+	registry image.Source
+	queue    workqueue.TypedRateLimitingInterface[string]
+
+	snapshotStore store.Store[*providerapi.Snapshot]
+	imageStore    store.Store[*providerapi.Image]
+	volumeStore   store.Store[*providerapi.Volume]
+
+	events         event.Source[*providerapi.Volume]
+	imageEvents    event.Source[*providerapi.Image]
+	snapshotEvents event.Source[*providerapi.Snapshot]
+
+	workerSize int
+}
+
+func (r *VolumeReconciler) Start(ctx context.Context) error {
+	log := r.log
+
+	reg, err := r.events.AddHandler(event.HandlerFunc[*providerapi.Volume](func(event event.Event[*providerapi.Volume]) {
+		r.queue.Add(event.Object.ID)
+	}))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = r.events.RemoveHandler(reg)
+	}()
+
+	imageReg, err := r.imageEvents.AddHandler(event.HandlerFunc[*providerapi.Image](func(evt event.Event[*providerapi.Image]) {
+		r.requeueVolumesForImage(ctx, evt.Object.ID)
+	}))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = r.imageEvents.RemoveHandler(imageReg)
+	}()
+
+	snapshotReg, err := r.snapshotEvents.AddHandler(event.HandlerFunc[*providerapi.Snapshot](func(evt event.Event[*providerapi.Snapshot]) {
+		if evt.Type != event.TypeUpdated && evt.Type != event.TypeDeleted {
+			return
+		}
+		if evt.Object.Status.State != providerapi.SnapshotStateReady &&
+			evt.Object.Status.State != providerapi.SnapshotStateFailed &&
+			evt.Object.DeletedAt == nil {
+			return
+		}
+		r.requeueVolumesForSnapshot(ctx, evt.Object.ID)
+	}))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = r.snapshotEvents.RemoveHandler(snapshotReg)
+	}()
+
+	go func() {
+		<-ctx.Done()
+		r.queue.ShutDown()
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < r.workerSize; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for r.processNextWorkItem(ctx, log) {
+			}
+		}()
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func (r *VolumeReconciler) requeueVolumesForImage(ctx context.Context, imageID string) {
+	// TODO: Requeue OS Volumes when their base image becomes Available
+	// OS volumes waiting for a base image have an empty ImageRef,
+	// so they are not matched here. We need to connect the base images to the volumes somehow
+	volumes, err := r.volumeStore.List(ctx, store.MatchingFields{providerapi.VolumeStatusImageRefField: imageID})
+	if err != nil {
+		r.log.Error(err, "failed to list volumes for image event requeue")
+		return
+	}
+	for _, vol := range volumes {
+		r.queue.Add(vol.ID)
+	}
+}
+
+func (r *VolumeReconciler) requeueVolumesForSnapshot(ctx context.Context, snapshotID string) {
+	// TODO: Requeue OS Volumes when their intermediate snapshot becomes Ready or Failed.
+	// OS volumes waiting for a intermediate snapshot have no SnapshotSource,
+	// so they are not matched here. We need to connect the snapshots to the volumes somehow
+	volumes, err := r.volumeStore.List(ctx, store.MatchingFields{providerapi.VolumeSpecSourceSnapshotSourceField: snapshotID})
+	if err != nil {
+		r.log.Error(err, "failed to list volumes for snapshot event requeue")
+		return
+	}
+	for _, vol := range volumes {
+		r.queue.Add(vol.ID)
+	}
+}
+
+func (r *VolumeReconciler) processNextWorkItem(ctx context.Context, log logr.Logger) bool {
+	id, shutdown := r.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer r.queue.Done(id)
+
+	log = log.WithValues("volumeId", id)
+	ctx = logr.NewContext(ctx, log)
+
+	if err := r.reconcileVolume(ctx, id); err != nil {
+		log.Error(err, "failed to reconcile volume")
+		r.queue.AddRateLimited(id)
+		return true
+	}
+
+	r.queue.Forget(id)
+	return true
+}
+
+const (
+	VolumeFinalizer     = "volume"
+	VolumeImageIDPrefix = "vol-"
+	BaseImageIDPrefix   = "os-"
+)
+
+func (r *VolumeReconciler) reconcileVolume(ctx context.Context, id string) error {
+	log := logr.FromContextOrDiscard(ctx)
+
+	volume, err := r.volumeStore.Get(ctx, id)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("failed to fetch volume from store: %w", err)
+		}
+		return nil
+	}
+
+	if volume.DeletedAt != nil {
+		if err := r.deleteVolume(ctx, log, volume); err != nil {
+			return fmt.Errorf("failed to delete volume: %w", err)
+		}
+		return nil
+	}
+
+	if !slices.Contains(volume.Finalizers, VolumeFinalizer) {
+		volume.Finalizers = append(volume.Finalizers, VolumeFinalizer)
+		if _, err := r.volumeStore.Update(ctx, volume); err != nil {
+			return fmt.Errorf("failed to set finalizers: %w", err)
+		}
+		return nil
+	}
+
+	// If volume already has an ImageRef, check the referenced image's state
+	if volume.Status.ImageRef != "" {
+		img, err := r.imageStore.Get(ctx, volume.Status.ImageRef)
+		if err != nil {
+			if !errors.Is(err, store.ErrNotFound) {
+				return fmt.Errorf("failed to get image: %w", err)
+			}
+
+			// Image was deleted, clear the ref and recreate the image
+			log.V(1).Info("Referenced image not found, clearing ImageRef", "imageId", volume.Status.ImageRef)
+			volume.Status.ImageRef = ""
+			if _, err := r.volumeStore.Update(ctx, volume); err != nil {
+				return fmt.Errorf("failed to clear image ref: %w", err)
+			}
+			return nil
+		}
+
+		// If the image was cloned from a snapshot that has since been deleted,
+		// clear SnapshotSource so the image proceeds as standalone.
+		if img.Spec.SnapshotSource != nil {
+			if _, err := r.snapshotStore.Get(ctx, *img.Spec.SnapshotSource); err != nil {
+				if !errors.Is(err, store.ErrNotFound) {
+					return fmt.Errorf("failed to get snapshot source: %w", err)
+				}
+				log.V(1).Info("Referenced snapshot not found, clearing SnapshotSource", "imageId", img.ID, "snapshotId", *img.Spec.SnapshotSource)
+				img.Spec.SnapshotSource = nil
+				if _, err := r.imageStore.Update(ctx, img); err != nil {
+					return fmt.Errorf("failed to clear snapshot source on image: %w", err)
+				}
+				return nil
+			}
+		}
+
+		// Image exists, reconcile volume state
+		switch img.Status.State {
+		case providerapi.ImageStatePending:
+			log.V(1).Info("Image is pending, waiting until it is available", "imageId", img.ID)
+			return nil
+		case providerapi.ImageStateAvailable:
+			var desiredAccess *providerapi.VolumeAccess
+			if img.Status.Access != nil {
+				desiredAccess = &providerapi.VolumeAccess{
+					Monitors: img.Status.Access.Monitors,
+					Handle:   img.Status.Access.Handle,
+					User:     img.Status.Access.User,
+					UserKey:  img.Status.Access.UserKey,
+				}
+			}
+			changed := volume.Status.Size != img.Status.Size || !volumeAccessEqual(volume.Status.Access, desiredAccess)
+			if volume.Status.State == providerapi.VolumeStateAvailable && !changed {
+				log.V(2).Info("Image is available, no status changes", "imageId", img.ID)
+				return nil
+			}
+			log.V(1).Info("Image is available, updating volume status", "imageId", img.ID)
+			volume.Status.State = providerapi.VolumeStateAvailable
+			volume.Status.Size = img.Status.Size
+			volume.Status.Access = desiredAccess
+			if _, err := r.volumeStore.Update(ctx, volume); err != nil {
+				return fmt.Errorf("failed to update volume status: %w", err)
+			}
+			return nil
+		default:
+			return fmt.Errorf("image %s in unexpected state: %s", img.ID, img.Status.State)
+		}
+	}
+
+	// ImageRef is empty, need to create the image based on volume source
+	switch {
+	case volume.Spec.Source.OSVolume == nil && volume.Spec.Source.SnapshotSource == nil:
+		return r.reconcileEmptyVolume(ctx, log, volume)
+	case volume.Spec.Source.OSVolume != nil && volume.Spec.Source.SnapshotSource == nil:
+		return r.reconcileOSVolume(ctx, log, volume)
+	case volume.Spec.Source.OSVolume == nil && volume.Spec.Source.SnapshotSource != nil:
+		return r.reconcileRestoredVolume(ctx, log, volume)
+	default:
+		return fmt.Errorf("invalid volume specification")
+	}
+}
+
+func (r *VolumeReconciler) reconcileEmptyVolume(ctx context.Context, log logr.Logger, volume *providerapi.Volume) error {
+	log.V(2).Info("Reconciling empty volume")
+
+	imageID := VolumeImageIDPrefix + volume.ID
+	img := &providerapi.Image{
+		Metadata: apiutils.Metadata{
+			ID: imageID,
+		},
+		Spec: providerapi.ImageSpec{
+			Size:   volume.Spec.Size,
+			WWN:    volume.Spec.WWN,
+			Limits: volume.Spec.Limits,
+			Encryption: providerapi.EncryptionSpec{
+				Type:                providerapi.EncryptionType(volume.Spec.VolumeEncryption.Type),
+				EncryptedPassphrase: volume.Spec.VolumeEncryption.EncryptedPassphrase,
+			},
+			SnapshotSource: nil,
+		},
+	}
+
+	createdImage, err := r.imageStore.Create(ctx, img)
+	if err != nil {
+		if !errors.Is(err, store.ErrAlreadyExists) {
+			return fmt.Errorf("failed to create image: %w", err)
+		}
+		log.V(2).Info("Image already exists", "imageId", imageID)
+		createdImage, err = r.imageStore.Get(ctx, imageID)
+		if err != nil {
+			return fmt.Errorf("failed to get created image: %w", err)
+		}
+	} else {
+		log.V(1).Info("Image created", "imageId", createdImage.ID)
+	}
+
+	if volume.Status.ImageRef != createdImage.ID {
+		volume.Status.ImageRef = createdImage.ID
+		if _, err := r.volumeStore.Update(ctx, volume); err != nil {
+			return fmt.Errorf("failed to update volume with image ref: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *VolumeReconciler) reconcileOSVolume(ctx context.Context, log logr.Logger, volume *providerapi.Volume) error {
+	log.V(2).Info("Reconciling OS volume")
+
+	if volume.Spec.Source.OSVolume == nil {
+		return fmt.Errorf("OS volume source is nil")
+	}
+	osVolume := volume.Spec.Source.OSVolume
+
+	// Step 1: Resolve OCI image to get digest
+	log.V(2).Info("Resolving OCI image", "ociImageName", osVolume.Name)
+	imageSource, err := createImageSource(toPlatform(osVolume.Architecture))
+	if err != nil {
+		return fmt.Errorf("failed to create image source: %w", err)
+	}
+	ociImage, err := imageSource.Resolve(ctx, osVolume.Name)
+	if err != nil {
+		return fmt.Errorf("failed to resolve OCI image %s: %w", osVolume.Name, err)
+	}
+
+	// Step 2: Get or create base image
+	imageDigest := ociImage.Descriptor().Digest
+	baseImageID := BaseImageIDPrefix + imageDigest.Encoded()
+	snapshotID := imageDigest.Encoded()
+	log.V(2).Info("Using base image", "baseImageId", baseImageID, "snapshotId", snapshotID)
+	baseImage, err := r.imageStore.Get(ctx, baseImageID)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("failed to get base image: %w", err)
+		}
+
+		ironcoreImage, err := ironcoreimage.ResolveImage(ctx, ociImage)
+		if err != nil {
+			return fmt.Errorf("failed to resolve ironcore image: %w", err)
+		}
+		if ironcoreImage.RootFS == nil {
+			return fmt.Errorf("ironcore image %s has no rootfs", osVolume.Name)
+		}
+		imageSize := uint64(ironcoreImage.RootFS.Descriptor().Size)
+		rootFSDigest := ironcoreImage.RootFS.Descriptor().Digest
+
+		ref, err := reference.ParseNamed(osVolume.Name)
+		if err != nil {
+			return fmt.Errorf("failed to parse image reference %s: %w", osVolume.Name, err)
+		}
+		refDigest, err := reference.WithDigest(ref, rootFSDigest)
+		if err != nil {
+			return fmt.Errorf("failed to parse image reference %s: %w", osVolume.Name, err)
+		}
+		refStr := refDigest.String()
+
+		// Create base image
+		log.V(1).Info("Creating base image", "baseImageId", baseImageID)
+		baseImage = &providerapi.Image{
+			Metadata: apiutils.Metadata{
+				ID: baseImageID,
+			},
+			Spec: providerapi.ImageSpec{
+				Size:   imageSize,
+				WWN:    "", // Base image doesn't need WWN
+				Limits: providerapi.Limits{},
+				Encryption: providerapi.EncryptionSpec{
+					Type: providerapi.EncryptionTypeUnencrypted, // Base images are unencrypted
+				},
+				Reference:      &refStr,
+				SnapshotSource: nil,
+			},
+		}
+
+		baseImage, err = r.imageStore.Create(ctx, baseImage)
+		if err != nil {
+			if !errors.Is(err, store.ErrAlreadyExists) {
+				return fmt.Errorf("failed to create base image: %w", err)
+			}
+			log.V(1).Info("Base image already exists, fetching", "baseImageId", baseImageID)
+			baseImage, err = r.imageStore.Get(ctx, baseImageID)
+			if err != nil {
+				return fmt.Errorf("failed to get existing base image: %w", err)
+			}
+		}
+	}
+
+	// Step 3: Check base image state
+	switch baseImage.Status.State {
+	case providerapi.ImageStatePending:
+		log.V(1).Info("Base image is pending, waiting", "baseImageId", baseImage.ID)
+		return nil
+	case providerapi.ImageStateAvailable:
+		log.V(2).Info("Base image is available", "baseImageId", baseImage.ID)
+	default:
+		return fmt.Errorf("base image %s in unexpected state: %s", baseImage.ID, baseImage.Status.State)
+	}
+
+	// Step 4: Get or create snapshot of base image
+	snapshot, err := r.snapshotStore.Get(ctx, snapshotID)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("failed to get snapshot %s: %w", snapshotID, err)
+		}
+
+		// Create snapshot
+		log.V(1).Info("Creating snapshot of base image", "snapshotId", snapshotID, "baseImageId", baseImageID)
+		snapshot = &providerapi.Snapshot{
+			Metadata: apiutils.Metadata{
+				ID: snapshotID,
+			},
+			Spec: providerapi.SnapshotSpec{
+				ImageRef:   baseImageID,
+				Protection: providerapi.SnapshotProtectionProtected, // Protection needed for cloning
+			},
+		}
+
+		snapshot, err = r.snapshotStore.Create(ctx, snapshot)
+		if err != nil {
+			if !errors.Is(err, store.ErrAlreadyExists) {
+				return fmt.Errorf("failed to create snapshot: %w", err)
+			}
+			log.V(1).Info("Snapshot already exists, fetching", "snapshotId", snapshotID)
+			snapshot, err = r.snapshotStore.Get(ctx, snapshotID)
+			if err != nil {
+				return fmt.Errorf("failed to get existing snapshot: %w", err)
+			}
+		}
+	}
+
+	// Step 5: Check snapshot state
+	switch snapshot.Status.State {
+	case providerapi.SnapshotStatePending:
+		log.V(1).Info("Snapshot is pending, waiting", "snapshotId", snapshot.ID)
+		return nil
+	case providerapi.SnapshotStateReady:
+		log.V(2).Info("Snapshot is ready", "snapshotId", snapshot.ID)
+	case providerapi.SnapshotStateFailed:
+		log.V(1).Info("Snapshot failed, recreating", "snapshotId", snapshot.ID)
+		if err := r.snapshotStore.Delete(ctx, snapshot.ID); err != nil {
+			if !errors.Is(err, store.ErrNotFound) {
+				return fmt.Errorf("failed to delete snapshot %s: %w", snapshot.ID, err)
+			}
+		}
+		log.V(2).Info("Deleted failed snapshot", "snapshotId", snapshot.ID)
+		return nil
+	default:
+		return fmt.Errorf("snapshot %s in unexpected state: %s", snapshotID, snapshot.Status.State)
+	}
+
+	// Step 6: Create volume's image as clone from snapshot
+	volumeImageID := VolumeImageIDPrefix + volume.ID
+	log.V(1).Info("Creating volume image from snapshot", "snapshotId", snapshotID, "imageId", volumeImageID)
+	volumeImage := &providerapi.Image{
+		Metadata: apiutils.Metadata{
+			ID: volumeImageID,
+		},
+		Spec: providerapi.ImageSpec{
+			Size:   volume.Spec.Size,
+			WWN:    volume.Spec.WWN,
+			Limits: volume.Spec.Limits,
+			Encryption: providerapi.EncryptionSpec{
+				Type:                providerapi.EncryptionType(volume.Spec.VolumeEncryption.Type),
+				EncryptedPassphrase: volume.Spec.VolumeEncryption.EncryptedPassphrase,
+			},
+			SnapshotSource: &snapshotID,
+		},
+	}
+
+	createdImage, err := r.imageStore.Create(ctx, volumeImage)
+	if err != nil {
+		if !errors.Is(err, store.ErrAlreadyExists) {
+			return fmt.Errorf("failed to create volume image: %w", err)
+		}
+		log.V(2).Info("Volume image already exists", "imageId", volumeImageID, "snapshotId", snapshotID)
+		createdImage, err = r.imageStore.Get(ctx, volumeImageID)
+		if err != nil {
+			return fmt.Errorf("failed to get created image: %w", err)
+		}
+	} else {
+		log.V(1).Info("Volume image created", "imageId", createdImage.ID, "snapshotId", snapshotID)
+	}
+
+	// Step 7: Update volume status with ImageRef
+	if volume.Status.ImageRef != createdImage.ID {
+		volume.Status.ImageRef = createdImage.ID
+		if _, err := r.volumeStore.Update(ctx, volume); err != nil {
+			return fmt.Errorf("failed to update volume with image ref: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *VolumeReconciler) reconcileRestoredVolume(ctx context.Context, log logr.Logger, volume *providerapi.Volume) error {
+	log.V(2).Info("Reconciling restored volume from snapshot")
+
+	if volume.Spec.Source.SnapshotSource == nil {
+		return fmt.Errorf("snapshot source is nil")
+	}
+	snapshotID := *volume.Spec.Source.SnapshotSource
+
+	snapshot, err := r.snapshotStore.Get(ctx, snapshotID)
+	if err != nil {
+		return fmt.Errorf("failed to get snapshot %s: %w", snapshotID, err)
+	}
+
+	switch snapshot.Status.State {
+	case providerapi.SnapshotStatePending:
+		log.V(1).Info("Snapshot is pending, waiting", "snapshotId", snapshotID)
+		return nil
+	case providerapi.SnapshotStateReady:
+		log.V(2).Info("Snapshot is ready", "snapshotId", snapshotID)
+	case providerapi.SnapshotStateFailed:
+		return fmt.Errorf("snapshot %s failed", snapshotID)
+	default:
+		return fmt.Errorf("snapshot %s in unexpected state: %s", snapshotID, snapshot.Status.State)
+	}
+
+	// Create new Image from snapshot
+	imageID := VolumeImageIDPrefix + volume.ID
+	log.V(1).Info("Creating image from snapshot", "snapshotId", snapshotID, "imageId", imageID)
+	img := &providerapi.Image{
+		Metadata: apiutils.Metadata{
+			ID: imageID,
+		},
+		Spec: providerapi.ImageSpec{
+			Size:   volume.Spec.Size,
+			WWN:    volume.Spec.WWN,
+			Limits: volume.Spec.Limits,
+			Encryption: providerapi.EncryptionSpec{
+				Type:                providerapi.EncryptionType(volume.Spec.VolumeEncryption.Type),
+				EncryptedPassphrase: volume.Spec.VolumeEncryption.EncryptedPassphrase,
+			},
+			SnapshotSource: &snapshotID,
+		},
+	}
+
+	createdImage, err := r.imageStore.Create(ctx, img)
+	if err != nil {
+		if !errors.Is(err, store.ErrAlreadyExists) {
+			return fmt.Errorf("failed to create image: %w", err)
+		}
+		log.V(2).Info("Image already exists", "imageId", imageID, "snapshotId", snapshotID)
+		createdImage, err = r.imageStore.Get(ctx, imageID)
+		if err != nil {
+			return fmt.Errorf("failed to get created image: %w", err)
+		}
+	} else {
+		log.V(1).Info("Image created from snapshot", "ImageId", createdImage.ID, "SnapshotId", snapshotID)
+	}
+
+	// Update volume status with ImageRef
+	if volume.Status.ImageRef != createdImage.ID {
+		volume.Status.ImageRef = createdImage.ID
+		if _, err := r.volumeStore.Update(ctx, volume); err != nil {
+			return fmt.Errorf("failed to update volume with image ref: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *VolumeReconciler) deleteVolume(ctx context.Context, log logr.Logger, volume *providerapi.Volume) error {
+	if !slices.Contains(volume.Finalizers, VolumeFinalizer) {
+		log.V(1).Info("volume has no finalizer: done")
+		return nil
+	}
+
+	// Delete the volume's Image if it exists
+	imageRef := volume.Status.ImageRef
+	if imageRef != "" {
+		if err := r.imageStore.Delete(ctx, imageRef); err != nil {
+			if !errors.Is(err, store.ErrNotFound) {
+				return fmt.Errorf("failed to delete image %s: %w", imageRef, err)
+			}
+			log.V(2).Info("Image already deleted", "imageId", imageRef)
+		} else {
+			log.V(1).Info("Image deleted", "imageId", imageRef)
+		}
+	}
+
+	// Note: We do NOT delete base images or snapshots for OS volumes
+	// as they may be shared by multiple volumes (golden image pattern).
+	// Clean up of unused base images and snapshots can be added later.
+
+	volume.Finalizers = utils.DeleteSliceElement(volume.Finalizers, VolumeFinalizer)
+	if _, err := r.volumeStore.Update(ctx, volume); store.IgnoreErrNotFound(err) != nil {
+		return fmt.Errorf("failed to update volume metadata: %w", err)
+	}
+	log.V(2).Info("Removed volume finalizer")
+	return nil
+}
+
+func volumeAccessEqual(a, b *providerapi.VolumeAccess) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Monitors == b.Monitors && a.Handle == b.Handle && a.User == b.User && a.UserKey == b.UserKey
+}

--- a/internal/limits/calc.go
+++ b/internal/limits/calc.go
@@ -5,6 +5,7 @@ package limits
 
 import (
 	"github.com/ironcore-dev/ceph-provider/api"
+	apiv2 "github.com/ironcore-dev/ceph-provider/api/v2"
 )
 
 func Calculate(iops, tps int64, burstFactor, burstDurationInSeconds int64) api.Limits {
@@ -38,6 +39,38 @@ func Calculate(iops, tps int64, burstFactor, burstDurationInSeconds int64) api.L
 	limits[api.WriteBPSBurstLimit] = tpsBurstLimit
 
 	limits[api.BPSBurstDurationLimit] = burstDurationInSeconds
+
+	return limits
+}
+
+func CalculateV2(iops, tps int64, burstFactor, burstDurationInSeconds int64) apiv2.Limits {
+	limits := map[apiv2.LimitType]int64{}
+
+	var scale int64 = 1
+
+	iops = iops * scale
+	limits[apiv2.IOPSLimit] = iops
+	limits[apiv2.ReadIOPSLimit] = iops
+	limits[apiv2.WriteIOPSLimit] = iops
+
+	iopsBurstLimit := burstFactor * iops
+	limits[apiv2.IOPSBurstLimit] = iopsBurstLimit
+	limits[apiv2.ReadIOPSBurstLimit] = iopsBurstLimit
+	limits[apiv2.WriteIOPSBurstLimit] = iopsBurstLimit
+
+	limits[apiv2.IOPSBurstDurationLimit] = burstDurationInSeconds
+
+	tps = tps * scale
+	limits[apiv2.BPSLimit] = tps
+	limits[apiv2.ReadBPSLimit] = tps
+	limits[apiv2.WriteBPSLimit] = tps
+
+	tpsBurstLimit := burstFactor * tps
+	limits[apiv2.BPSBurstLimit] = tpsBurstLimit
+	limits[apiv2.ReadBPSBurstLimit] = tpsBurstLimit
+	limits[apiv2.WriteBPSBurstLimit] = tpsBurstLimit
+
+	limits[apiv2.BPSBurstDurationLimit] = burstDurationInSeconds
 
 	return limits
 }

--- a/internal/omap/config.go
+++ b/internal/omap/config.go
@@ -4,6 +4,9 @@
 package omap
 
 const (
-	NameVolumes   = "ironcore.csi.volumes"
-	NameSnapshots = "ironcore.csi.snapshots"
+	LegacyNameVolumes   = "ironcore.csi.volumes"
+	LegacyNameSnapshots = "ironcore.csi.snapshots"
+	NameVolumes         = "ironcore.volumes"
+	NameImages          = "ironcore.images"
+	NameSnapshots       = "ironcore.snapshots"
 )

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 
 	"github.com/ironcore-dev/ceph-provider/api"
+	apiv2 "github.com/ironcore-dev/ceph-provider/api/v2"
 	"github.com/ironcore-dev/ironcore/broker/common/idgen"
 )
 
@@ -29,4 +30,33 @@ type imageStrategy struct {
 func (i imageStrategy) PrepareForCreate(obj *api.Image) {
 	obj.Spec.WWN = i.WWNGen.Generate()
 	obj.Status = api.ImageStatus{State: api.ImageStatePending}
+}
+
+var VolumeStrategy = volumeStrategy{}
+
+type volumeStrategy struct{}
+
+func (volumeStrategy) PrepareForCreate(obj *apiv2.Volume) {
+	obj.Status = apiv2.VolumeStatus{State: apiv2.VolumeStatePending}
+}
+
+var ImageV2Strategy = imageV2Strategy{
+	WWNGen: idgen.NewIDGen(rand.Reader, 16),
+}
+
+type imageV2Strategy struct {
+	WWNGen idgen.IDGen
+}
+
+func (i imageV2Strategy) PrepareForCreate(obj *apiv2.Image) {
+	obj.Spec.WWN = i.WWNGen.Generate()
+	obj.Status = apiv2.ImageStatus{State: apiv2.ImageStatePending}
+}
+
+var SnapshotV2Strategy = snapshotV2Strategy{}
+
+type snapshotV2Strategy struct{}
+
+func (snapshotV2Strategy) PrepareForCreate(obj *apiv2.Snapshot) {
+	obj.Status = apiv2.SnapshotStatus{State: apiv2.SnapshotStatePending}
 }

--- a/internal/volumeserver/v2/event_list.go
+++ b/internal/volumeserver/v2/event_list.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	api "github.com/ironcore-dev/ceph-provider/api/v2"
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	irievent "github.com/ironcore-dev/ironcore/iri/apis/event/v1alpha1"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
+	"github.com/ironcore-dev/provider-utils/eventutils/recorder"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func (s *Server) filterEvents(log logr.Logger, events []*recorder.Event, filter *iri.EventFilter) []*recorder.Event {
+	if filter == nil {
+		return events
+	}
+
+	var (
+		res []*recorder.Event
+		sel = labels.SelectorFromSet(filter.LabelSelector)
+	)
+	for _, iriEvent := range events {
+		originLabel, err := apiutils.GetLabelsAnnotation(iriEvent.InvolvedObjectMeta, api.LabelsAnnotation)
+		if err != nil {
+			log.V(1).Info("Failed to get Labels from iriEvent")
+			continue
+		}
+
+		if !sel.Matches(labels.Set(originLabel)) {
+			continue
+		}
+
+		if filter.EventsFromTime > 0 && filter.EventsToTime > 0 {
+			if iriEvent.EventTime < filter.EventsFromTime || iriEvent.EventTime > filter.EventsToTime {
+				continue
+			}
+		}
+
+		res = append(res, iriEvent)
+	}
+	return res
+}
+
+func (s *Server) convertEventToIriEvent(events []*recorder.Event) ([]*irievent.Event, error) {
+	var res []*irievent.Event
+
+	for _, event := range events {
+		metadata, err := api.GetObjectMetadata(event.InvolvedObjectMeta)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get object metadata: %w", err)
+		}
+		res = append(res, &irievent.Event{
+			Spec: &irievent.EventSpec{
+				InvolvedObjectMeta: metadata,
+				Reason:             event.Reason,
+				Message:            event.Message,
+				Type:               event.Type,
+				EventTime:          event.EventTime,
+			},
+		})
+	}
+	return res, nil
+}
+
+func (s *Server) ListEvents(ctx context.Context, req *iri.ListEventsRequest) (*iri.ListEventsResponse, error) {
+	log := s.loggerFrom(ctx)
+
+	events := s.volumeEventStore.ListEvents()
+	filteredEvents := s.filterEvents(log, events, req.Filter)
+	iriEvents, err := s.convertEventToIriEvent(filteredEvents)
+	if err != nil {
+		return nil, utils.ConvertInternalErrorToGRPC(err)
+	}
+
+	return &iri.ListEventsResponse{
+		Events: iriEvents,
+	}, nil
+}

--- a/internal/volumeserver/v2/server.go
+++ b/internal/volumeserver/v2/server.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	api "github.com/ironcore-dev/ceph-provider/api/v2"
+	"github.com/ironcore-dev/ceph-provider/internal/ceph"
+	"github.com/ironcore-dev/ceph-provider/internal/encryption"
+	"github.com/ironcore-dev/ironcore/broker/common/idgen"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	"github.com/ironcore-dev/provider-utils/eventutils/recorder"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type VolumeClassRegistry interface {
+	Get(volumeClassName string) (*iri.VolumeClass, bool)
+	List() []*iri.VolumeClass
+}
+
+type Server struct {
+	iri.UnimplementedVolumeRuntimeServer
+	idGen idgen.IDGen
+
+	volumeStore      store.Store[*api.Volume]
+	snapshotStore    store.Store[*api.Snapshot]
+	volumeEventStore recorder.EventStore
+
+	volumeClasses     VolumeClassRegistry
+	cephCommandClient ceph.Command
+
+	burstFactor            int64
+	burstDurationInSeconds int64
+
+	keyEncryption encryption.Encryptor
+}
+
+func (s *Server) loggerFrom(ctx context.Context, keysWithValues ...interface{}) logr.Logger {
+	return ctrl.LoggerFrom(ctx, keysWithValues...)
+}
+
+type Options struct {
+	IDGen idgen.IDGen
+
+	BurstFactor            int64
+	BurstDurationInSeconds int64
+
+	VolumeEventStore recorder.EventStore
+}
+
+func setOptionsDefaults(o *Options) {
+	if o.IDGen == nil {
+		o.IDGen = idgen.Default
+	}
+}
+
+var _ iri.VolumeRuntimeServer = (*Server)(nil)
+
+func New(
+	volumeStore store.Store[*api.Volume],
+	snapshotStore store.Store[*api.Snapshot],
+	volumeClassRegistry VolumeClassRegistry,
+	keyEncryption encryption.Encryptor,
+	cephCommandClient ceph.Command,
+	opts Options,
+) (*Server, error) {
+	setOptionsDefaults(&opts)
+
+	return &Server{
+		idGen:            opts.IDGen,
+		volumeStore:      volumeStore,
+		snapshotStore:    snapshotStore,
+		volumeEventStore: opts.VolumeEventStore,
+		volumeClasses:    volumeClassRegistry,
+
+		keyEncryption:     keyEncryption,
+		cephCommandClient: cephCommandClient,
+
+		burstFactor:            opts.BurstFactor,
+		burstDurationInSeconds: opts.BurstDurationInSeconds,
+	}, nil
+}

--- a/internal/volumeserver/v2/snapshot.go
+++ b/internal/volumeserver/v2/snapshot.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"fmt"
+
+	api "github.com/ironcore-dev/ceph-provider/api/v2"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+)
+
+func (s *Server) convertSnapshotToIRI(snapshot *api.Snapshot) (*iri.VolumeSnapshot, error) {
+	metadata, err := api.GetObjectMetadataFromObjectID(snapshot.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("error getting iri metadata: %w", err)
+	}
+
+	state, err := s.getIriSnapshotState(snapshot.Status.State)
+	if err != nil {
+		return nil, fmt.Errorf("error getting iri state: %w", err)
+	}
+
+	return &iri.VolumeSnapshot{
+		Metadata: metadata,
+		Spec: &iri.VolumeSnapshotSpec{
+			VolumeId: snapshot.Spec.ImageRef,
+		},
+		Status: &iri.VolumeSnapshotStatus{
+			State: state,
+			Size:  snapshot.Status.Size,
+		},
+	}, nil
+}
+
+func (s *Server) getIriSnapshotState(state api.SnapshotState) (iri.VolumeSnapshotState, error) {
+	switch state {
+	case api.SnapshotStateReady:
+		return iri.VolumeSnapshotState_VOLUME_SNAPSHOT_READY, nil
+	case api.SnapshotStatePending:
+		return iri.VolumeSnapshotState_VOLUME_SNAPSHOT_PENDING, nil
+	case api.SnapshotStateFailed:
+		return iri.VolumeSnapshotState_VOLUME_SNAPSHOT_FAILED, nil
+	default:
+		return 0, fmt.Errorf("unknown volume snapshot state '%q'", state)
+	}
+}

--- a/internal/volumeserver/v2/status.go
+++ b/internal/volumeserver/v2/status.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+)
+
+func (s *Server) Status(ctx context.Context, req *iri.StatusRequest) (*iri.StatusResponse, error) {
+	log := s.loggerFrom(ctx)
+	log.V(1).Info("Volume Status called")
+
+	log.V(1).Info("Listing ironcore volume classes")
+	volumeClassList := s.volumeClasses.List()
+
+	log.V(1).Info("Getting ceph pool stats")
+	poolStats, err := s.cephCommandClient.PoolStats()
+	if err != nil {
+		return nil, utils.ConvertInternalErrorToGRPC(fmt.Errorf("failed to get ceph pool stats: %w", err))
+	}
+
+	var volumeClassStatus []*iri.VolumeClassStatus
+	for _, volumeClass := range volumeClassList {
+		volumeClassStatus = append(volumeClassStatus, &iri.VolumeClassStatus{
+			VolumeClass: volumeClass,
+			Quantity:    poolStats.MaxAvail,
+		})
+	}
+
+	log.V(1).Info("Returning status with volume classes")
+	return &iri.StatusResponse{
+		VolumeClassStatus: volumeClassStatus,
+	}, nil
+}

--- a/internal/volumeserver/v2/version.go
+++ b/internal/volumeserver/v2/version.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"context"
+
+	"github.com/blang/semver/v4"
+	"github.com/ironcore-dev/ceph-provider/internal/volumeserver/version"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+)
+
+func (s *Server) Version(context.Context, *iri.VersionRequest) (*iri.VersionResponse, error) {
+	var runtimeVersion string
+	switch {
+	case version.Version != "":
+		runtimeVersion = version.Version
+	case version.Commit != "":
+		v, err := semver.NewBuildVersion(version.Commit)
+		if err != nil {
+			runtimeVersion = "0.0.0"
+		} else {
+			runtimeVersion = v
+		}
+	default:
+		runtimeVersion = "0.0.0"
+	}
+
+	return &iri.VersionResponse{
+		RuntimeName:    version.RuntimeName,
+		RuntimeVersion: runtimeVersion,
+	}, nil
+}

--- a/internal/volumeserver/v2/volume.go
+++ b/internal/volumeserver/v2/volume.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"fmt"
+
+	api "github.com/ironcore-dev/ceph-provider/api/v2"
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+)
+
+const (
+	MonitorsKey = "monitors"
+	ImageKey    = "image"
+	UserIDKey   = "userID"
+	UserKeyKey  = "userKey"
+	DriverName  = "ceph"
+)
+
+func (s *Server) convertVolumeToIRI(volume *api.Volume) (*iri.Volume, error) {
+	metadata, err := api.GetObjectMetadataFromObjectID(volume.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("error getting iri metadata: %w", err)
+	}
+
+	spec, err := s.getIriVolumeSpec(volume)
+	if err != nil {
+		return nil, fmt.Errorf("error getting iri spec: %w", err)
+	}
+
+	state, err := s.getIriState(volume.Status.State)
+	if err != nil {
+		return nil, fmt.Errorf("error getting iri state: %w", err)
+	}
+
+	var access *iri.VolumeAccess
+	if state == iri.VolumeState_VOLUME_AVAILABLE && volume.Status.Access != nil {
+		access = &iri.VolumeAccess{
+			Driver: DriverName,
+			Handle: volume.Spec.WWN,
+			Attributes: map[string]string{
+				MonitorsKey: volume.Status.Access.Monitors,
+				ImageKey:    volume.Status.Access.Handle,
+			},
+			SecretData: map[string][]byte{
+				UserIDKey:  []byte(volume.Status.Access.User),
+				UserKeyKey: []byte(volume.Status.Access.UserKey),
+			},
+		}
+	}
+
+	volumeSize, err := utils.Uint64ToInt64(volume.Status.Size)
+	if err != nil {
+		return nil, err
+	}
+
+	return &iri.Volume{
+		Metadata: metadata,
+		Spec:     spec,
+		Status: &iri.VolumeStatus{
+			State:  state,
+			Access: access,
+			Resources: &iri.VolumeResources{
+				StorageBytes: volumeSize,
+			},
+		},
+	}, nil
+}
+
+func (s *Server) getIriVolumeSpec(volume *api.Volume) (*iri.VolumeSpec, error) {
+	storageBytes, err := utils.Uint64ToInt64(volume.Spec.Size)
+	if err != nil {
+		return nil, err
+	}
+
+	spec := &iri.VolumeSpec{
+		Resources: &iri.VolumeResources{
+			StorageBytes: storageBytes,
+		},
+	}
+
+	class, ok := api.GetClassLabelFromObject(volume)
+	if !ok {
+		return nil, fmt.Errorf("failed to get volume class for volume: %s", volume.ID)
+	}
+	spec.Class = class
+
+	return spec, nil
+}
+
+func (s *Server) getIriState(state api.VolumeState) (iri.VolumeState, error) {
+	switch state {
+	case api.VolumeStateAvailable:
+		return iri.VolumeState_VOLUME_AVAILABLE, nil
+	case api.VolumeStatePending:
+		return iri.VolumeState_VOLUME_PENDING, nil
+	default:
+		return 0, fmt.Errorf("unknown volume state '%q'", state)
+	}
+}

--- a/internal/volumeserver/v2/volume_create.go
+++ b/internal/volumeserver/v2/volume_create.go
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	api "github.com/ironcore-dev/ceph-provider/api/v2"
+	"github.com/ironcore-dev/ceph-provider/internal/limits"
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	iriv1alpha1 "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
+)
+
+const (
+	EncryptionSecretDataPassphraseKey = "encryptionKey"
+)
+
+func (s *Server) createVolumeFromIRI(ctx context.Context, log logr.Logger, iriVolume *iriv1alpha1.Volume) (*api.Volume, error) {
+	if iriVolume == nil {
+		return nil, fmt.Errorf("got an empty volume")
+	}
+
+	var imageSize uint64
+	var err error
+	if iriVolume.Spec.Resources != nil {
+		if imageSize, err = utils.Int64ToUint64(iriVolume.Spec.Resources.StorageBytes); err != nil {
+			return nil, fmt.Errorf("failed to get volume size: %w", err)
+		}
+	}
+
+	var encryptionSpec api.VolumeEncryptionSpec
+	if encryption := iriVolume.Spec.Encryption; encryption != nil {
+		if encryption.SecretData == nil {
+			return nil, fmt.Errorf("encryption enabled but SecretData missing")
+		}
+		passphrase, found := encryption.SecretData[EncryptionSecretDataPassphraseKey]
+		if !found {
+			return nil, fmt.Errorf("encryption enabled but secret data with key %q missing", EncryptionSecretDataPassphraseKey)
+		}
+
+		encryptedPassphrase, err := s.keyEncryption.Encrypt(passphrase)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encrypt passphrase: %w", err)
+		}
+		encryptionSpec = api.VolumeEncryptionSpec{
+			Type:                api.VolumeEncryptionTypeEncrypted,
+			EncryptedPassphrase: encryptedPassphrase,
+		}
+	}
+
+	log.V(2).Info("Getting volume class")
+	class, found := s.volumeClasses.Get(iriVolume.Spec.Class)
+	if !found {
+		return nil, fmt.Errorf("volume class '%s' not supported", iriVolume.Spec.Class)
+	}
+
+	log.V(2).Info("Getting volume limits")
+	calculatedLimits := limits.CalculateV2(class.Capabilities.Iops, class.Capabilities.Tps, s.burstFactor, s.burstDurationInSeconds)
+
+	var source api.VolumeSource
+	if dataSource := iriVolume.Spec.VolumeDataSource; dataSource != nil {
+		switch {
+		case dataSource.SnapshotDataSource != nil:
+			snapshotID := dataSource.SnapshotDataSource.SnapshotId
+			source.SnapshotSource = &snapshotID
+		case dataSource.ImageDataSource != nil:
+			if dataSource.ImageDataSource.Image == "" {
+				return nil, fmt.Errorf("must specify image url in image data source")
+			}
+			if imageSize == 0 {
+				return nil, fmt.Errorf("must specify size when creating volume from image data source")
+			}
+			var arch *string
+			if a := dataSource.ImageDataSource.Architecture; a != "" {
+				arch = &a
+			} else if iriVolume.Metadata != nil {
+				if a, ok := iriVolume.Metadata.Labels[api.MachineArchitectureLabel]; ok {
+					arch = &a
+				}
+			}
+			source.OSVolume = &api.OSVolumeSource{
+				Name:         dataSource.ImageDataSource.Image,
+				Architecture: arch,
+			}
+		default:
+			return nil, fmt.Errorf("unsupported or incomplete volume data source type")
+		}
+	}
+
+	volume := &api.Volume{
+		Metadata: apiutils.Metadata{
+			ID: s.idGen.Generate(),
+		},
+		Spec: api.VolumeSpec{
+			Size:             imageSize,
+			Limits:           calculatedLimits,
+			VolumeEncryption: encryptionSpec,
+			Source:           source,
+		},
+	}
+
+	log.V(2).Info("Setting volume metadata")
+	if err := api.SetObjectMetadataFromMetadata(volume, iriVolume.Metadata); err != nil {
+		return nil, fmt.Errorf("failed to set metadata: %w", err)
+	}
+	api.SetClassLabelForObject(volume, iriVolume.Spec.Class)
+	api.SetManagerLabel(volume, api.VolumeManager)
+
+	log.V(2).Info("Creating volume in store")
+	volume, err = s.volumeStore.Create(ctx, volume)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create volume: %w", err)
+	}
+
+	log.V(2).Info("Volume created", "VolumeID", volume.ID)
+	return volume, nil
+}
+
+func (s *Server) CreateVolume(ctx context.Context, req *iriv1alpha1.CreateVolumeRequest) (*iriv1alpha1.CreateVolumeResponse, error) {
+	log := s.loggerFrom(ctx)
+	log.V(1).Info("Creating volume")
+
+	volume, err := s.createVolumeFromIRI(ctx, log, req.Volume)
+	if err != nil {
+		return nil, utils.ConvertInternalErrorToGRPC(fmt.Errorf("unable to create volume: %w", err))
+	}
+
+	log = log.WithValues("VolumeID", volume.ID)
+
+	log.V(1).Info("Converting volume to IRI volume")
+	iriVolume, err := s.convertVolumeToIRI(volume)
+	if err != nil {
+		return nil, utils.ConvertInternalErrorToGRPC(fmt.Errorf("unable to convert volume: %w", err))
+	}
+
+	log.V(1).Info("Volume created", "Volume", iriVolume.Metadata.Id, "State", iriVolume.Status.State)
+	return &iriv1alpha1.CreateVolumeResponse{
+		Volume: iriVolume,
+	}, nil
+}

--- a/internal/volumeserver/v2/volume_delete.go
+++ b/internal/volumeserver/v2/volume_delete.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
+)
+
+func (s *Server) DeleteVolume(ctx context.Context, req *iri.DeleteVolumeRequest) (*iri.DeleteVolumeResponse, error) {
+	log := s.loggerFrom(ctx, "VolumeID", req.GetVolumeId())
+
+	log.V(1).Info("Deleting volume")
+	if err := s.volumeStore.Delete(ctx, req.VolumeId); err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			return nil, fmt.Errorf("error deleting volume: %w", err)
+		}
+		return nil, utils.ConvertInternalErrorToGRPC(fmt.Errorf("failed to get volume %s: %w", req.VolumeId, store.ErrNotFound))
+	}
+
+	log.V(1).Info("Volume deleted")
+	return &iri.DeleteVolumeResponse{}, nil
+}

--- a/internal/volumeserver/v2/volume_expand.go
+++ b/internal/volumeserver/v2/volume_expand.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+)
+
+func (s *Server) expandVolume(ctx context.Context, log logr.Logger, volumeID string, storageBytes int64) error {
+	log.V(2).Info("Fetching volume")
+	volume, err := s.volumeStore.Get(ctx, volumeID)
+	if err != nil {
+		return fmt.Errorf("unable to get volume: %w", err)
+	}
+
+	validatedStorageBytes, err := utils.Int64ToUint64(storageBytes)
+	if err != nil {
+		return err
+	}
+
+	if validatedStorageBytes <= volume.Spec.Size {
+		return fmt.Errorf("requested size %q must be greater than current size %q", storageBytes, volume.Spec.Size)
+	}
+
+	log.V(2).Info("Updating volume with new size", "storageBytes", storageBytes)
+	volume.Spec.Size = validatedStorageBytes
+	if _, err := s.volumeStore.Update(ctx, volume); err != nil {
+		return fmt.Errorf("failed to update volume: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Server) ExpandVolume(ctx context.Context, req *iri.ExpandVolumeRequest) (*iri.ExpandVolumeResponse, error) {
+	log := s.loggerFrom(ctx, "VolumeID", req.GetVolumeId())
+
+	log.V(1).Info("Expanding volume with new size", "storageBytes", req.Resources.StorageBytes)
+	if err := s.expandVolume(ctx, log, req.VolumeId, req.Resources.StorageBytes); err != nil {
+		return nil, utils.ConvertInternalErrorToGRPC(fmt.Errorf("failed to expand volume: %w", err))
+	}
+
+	log.V(1).Info("Volume expanded")
+	return &iri.ExpandVolumeResponse{}, nil
+}

--- a/internal/volumeserver/v2/volume_list.go
+++ b/internal/volumeserver/v2/volume_list.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	api "github.com/ironcore-dev/ceph-provider/api/v2"
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func (s *Server) getIriVolume(ctx context.Context, volumeID string) (*iri.Volume, error) {
+	volume, err := s.volumeStore.Get(ctx, volumeID)
+	if err != nil {
+		if errors.Is(err, utils.ErrVolumeNotFound) {
+			return nil, fmt.Errorf("failed to get volume %s: %w", volumeID, utils.ErrVolumeNotFound)
+		}
+		return nil, fmt.Errorf("failed to get volume: %w", err)
+	}
+
+	if !api.IsObjectManagedBy(volume, api.VolumeManager) {
+		return nil, fmt.Errorf("failed to get volume %s: %w", volumeID, utils.ErrVolumeIsntManaged)
+	}
+
+	return s.convertVolumeToIRI(volume)
+}
+
+func (s *Server) filterVolumes(volumes []*iri.Volume, filter *iri.VolumeFilter) []*iri.Volume {
+	if filter == nil {
+		return volumes
+	}
+
+	var (
+		res []*iri.Volume
+		sel = labels.SelectorFromSet(filter.LabelSelector)
+	)
+	for _, iriVolume := range volumes {
+		if !sel.Matches(labels.Set(iriVolume.Metadata.Labels)) {
+			continue
+		}
+
+		res = append(res, iriVolume)
+	}
+	return res
+}
+
+func (s *Server) listVolumes(ctx context.Context) ([]*iri.Volume, error) {
+	volumes, err := s.volumeStore.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error listing volumes: %w", err)
+	}
+
+	var res []*iri.Volume
+	for _, volume := range volumes {
+		if !api.IsObjectManagedBy(volume, api.VolumeManager) {
+			continue
+		}
+
+		iriVolume, err := s.convertVolumeToIRI(volume)
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, iriVolume)
+	}
+	return res, nil
+}
+
+func (s *Server) ListVolumes(ctx context.Context, req *iri.ListVolumesRequest) (*iri.ListVolumesResponse, error) {
+	log := s.loggerFrom(ctx)
+	log.V(2).Info("Listing volumes")
+
+	if filter := req.Filter; filter != nil && filter.Id != "" {
+		volume, err := s.getIriVolume(ctx, filter.Id)
+		if err != nil {
+			if !errors.Is(err, utils.ErrVolumeNotFound) && !errors.Is(err, utils.ErrVolumeIsntManaged) {
+				return nil, utils.ConvertInternalErrorToGRPC(err)
+			}
+			return &iri.ListVolumesResponse{
+				Volumes: []*iri.Volume{},
+			}, nil
+		}
+
+		return &iri.ListVolumesResponse{
+			Volumes: []*iri.Volume{volume},
+		}, nil
+	}
+
+	volumes, err := s.listVolumes(ctx)
+	if err != nil {
+		return nil, utils.ConvertInternalErrorToGRPC(err)
+	}
+
+	volumes = s.filterVolumes(volumes, req.Filter)
+
+	log.V(2).Info("Returning volumes list")
+	return &iri.ListVolumesResponse{
+		Volumes: volumes,
+	}, nil
+}

--- a/internal/volumeserver/v2/volumesnapshot_create.go
+++ b/internal/volumeserver/v2/volumesnapshot_create.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"context"
+	"fmt"
+
+	"errors"
+
+	"github.com/go-logr/logr"
+	api "github.com/ironcore-dev/ceph-provider/api/v2"
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	iriv1alpha1 "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
+)
+
+func (s *Server) createVolumeSnapshot(ctx context.Context, log logr.Logger, volumeSnapshot *iriv1alpha1.VolumeSnapshot) (*api.Snapshot, error) {
+	log.V(2).Info("Check if volume snapshot's source volume exists")
+	volumeID := volumeSnapshot.Spec.VolumeId
+	volume, err := s.volumeStore.Get(ctx, volumeID)
+	if err != nil {
+		if errors.Is(err, utils.ErrVolumeNotFound) {
+			return nil, fmt.Errorf("failed to get source volume %s: %w", volumeID, utils.ErrVolumeNotFound)
+		}
+		return nil, fmt.Errorf("failed to get source volume %s: %w", volumeID, err)
+	}
+	if volume.Status.State != api.VolumeStateAvailable {
+		return nil, fmt.Errorf("source volume %s is not available, current state is: %s", volumeID, volume.Status.State)
+	}
+
+	if volume.Status.ImageRef == "" {
+		return nil, fmt.Errorf("source volume %s has no image ref", volumeID)
+	}
+
+	snapshot := &api.Snapshot{
+		Metadata: apiutils.Metadata{
+			ID: s.idGen.Generate(),
+		},
+		Spec: api.SnapshotSpec{
+			ImageRef: volume.Status.ImageRef,
+		},
+	}
+
+	log.V(2).Info("Setting volume snapshot metadata")
+	if err := api.SetObjectMetadataFromMetadata(snapshot, volumeSnapshot.Metadata); err != nil {
+		return nil, fmt.Errorf("failed to set volume snapshot metadata: %w", err)
+	}
+	api.SetManagerLabel(snapshot, api.VolumeManager)
+
+	log.V(2).Info("Creating volume snapshot in store")
+	snapshot, err = s.snapshotStore.Create(ctx, snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create volume snapshot: %w", err)
+	}
+
+	return snapshot, nil
+}
+
+func (s *Server) CreateVolumeSnapshot(ctx context.Context, req *iriv1alpha1.CreateVolumeSnapshotRequest) (*iriv1alpha1.CreateVolumeSnapshotResponse, error) {
+	log := s.loggerFrom(ctx)
+	log.V(1).Info("Creating volume snapshot")
+
+	snapshot, err := s.createVolumeSnapshot(ctx, log, req.VolumeSnapshot)
+	if err != nil {
+		return nil, utils.ConvertInternalErrorToGRPC(fmt.Errorf("unable to create ceph snapshot: %w", err))
+	}
+
+	log = log.WithValues("VolumeSnapshotID", snapshot.ID, "State", snapshot.Status.State)
+
+	log.V(1).Info("Converting volume snapshot to IRI volume snapshot")
+	iriVolumeSnapshot, err := s.convertSnapshotToIRI(snapshot)
+	if err != nil {
+		return nil, utils.ConvertInternalErrorToGRPC(fmt.Errorf("unable to convert volume snapshot: %w", err))
+	}
+
+	log.V(1).Info("Volume snapshot created successfully")
+	return &iriv1alpha1.CreateVolumeSnapshotResponse{
+		VolumeSnapshot: iriVolumeSnapshot,
+	}, nil
+}

--- a/internal/volumeserver/v2/volumesnapshot_delete.go
+++ b/internal/volumeserver/v2/volumesnapshot_delete.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+)
+
+func (s *Server) DeleteVolumeSnapshot(ctx context.Context, req *iri.DeleteVolumeSnapshotRequest) (*iri.DeleteVolumeSnapshotResponse, error) {
+	log := s.loggerFrom(ctx, "SnapshotID", req.GetVolumeSnapshotId())
+
+	log.V(1).Info("Deleting volume snapshot")
+	if err := s.snapshotStore.Delete(ctx, req.VolumeSnapshotId); err != nil {
+		if !errors.Is(err, utils.ErrSnapshotNotFound) {
+			return nil, fmt.Errorf("error deleting volume snapshot: %w", err)
+		}
+		return nil, utils.ConvertInternalErrorToGRPC(fmt.Errorf("failed to delete volume snapshot %s: %w", req.VolumeSnapshotId, utils.ErrSnapshotNotFound))
+	}
+
+	log.V(1).Info("Volume snapshot deleted")
+	return &iri.DeleteVolumeSnapshotResponse{}, nil
+}

--- a/internal/volumeserver/v2/volumesnapshot_list.go
+++ b/internal/volumeserver/v2/volumesnapshot_list.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package volumeserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	api "github.com/ironcore-dev/ceph-provider/api/v2"
+	"github.com/ironcore-dev/ceph-provider/internal/utils"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func (s *Server) getIriVolumeSnapshot(ctx context.Context, snapshotId string) (*iri.VolumeSnapshot, error) {
+	snapshot, err := s.snapshotStore.Get(ctx, snapshotId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get snapshot %s: %w", snapshotId, err)
+	}
+
+	if !api.IsObjectManagedBy(snapshot, api.VolumeManager) {
+		return nil, fmt.Errorf("failed to get snapshot %s: %w", snapshotId, utils.ErrSnapshotIsntManaged)
+	}
+
+	return s.convertSnapshotToIRI(snapshot)
+}
+
+func (s *Server) filterSnapshots(snapshots []*iri.VolumeSnapshot, filter *iri.VolumeSnapshotFilter) []*iri.VolumeSnapshot {
+	if filter == nil {
+		return snapshots
+	}
+
+	var (
+		res []*iri.VolumeSnapshot
+		sel = labels.SelectorFromSet(filter.LabelSelector)
+	)
+	for _, iriSnapshot := range snapshots {
+		if !sel.Matches(labels.Set(iriSnapshot.Metadata.Labels)) {
+			continue
+		}
+
+		res = append(res, iriSnapshot)
+	}
+	return res
+}
+
+func (s *Server) listSnapshots(ctx context.Context) ([]*iri.VolumeSnapshot, error) {
+	snapshots, err := s.snapshotStore.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error listing snapshots: %w", err)
+	}
+
+	var res []*iri.VolumeSnapshot
+	for _, snapshot := range snapshots {
+		if !api.IsObjectManagedBy(snapshot, api.VolumeManager) {
+			continue
+		}
+
+		iriSnapshot, err := s.convertSnapshotToIRI(snapshot)
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, iriSnapshot)
+	}
+	return res, nil
+}
+
+func (s *Server) ListVolumeSnapshots(ctx context.Context, req *iri.ListVolumeSnapshotsRequest) (*iri.ListVolumeSnapshotsResponse, error) {
+	log := s.loggerFrom(ctx)
+	log.V(2).Info("Listing volume snapshots")
+
+	if filter := req.Filter; filter != nil && filter.Id != "" {
+		volumeSnapshot, err := s.getIriVolumeSnapshot(ctx, filter.Id)
+		if err != nil {
+			if !errors.Is(err, utils.ErrSnapshotNotFound) && !errors.Is(err, utils.ErrSnapshotIsntManaged) {
+				return nil, utils.ConvertInternalErrorToGRPC(err)
+			}
+			return &iri.ListVolumeSnapshotsResponse{
+				VolumeSnapshots: []*iri.VolumeSnapshot{},
+			}, nil
+		}
+
+		return &iri.ListVolumeSnapshotsResponse{
+			VolumeSnapshots: []*iri.VolumeSnapshot{volumeSnapshot},
+		}, nil
+	}
+
+	snapshots, err := s.listSnapshots(ctx)
+	if err != nil {
+		return nil, utils.ConvertInternalErrorToGRPC(err)
+	}
+
+	snapshots = s.filterSnapshots(snapshots, req.Filter)
+
+	log.V(2).Info("Returning volume snapshot list")
+	return &iri.ListVolumeSnapshotsResponse{
+		VolumeSnapshots: snapshots,
+	}, nil
+}

--- a/tests/integration/volume_create_integration_test.go
+++ b/tests/integration/volume_create_integration_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Create Volume", func() {
 		By("ensuring the correct image has been created inside the ceph cluster")
 		image := &api.Image{}
 		Eventually(ctx, func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", createResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", createResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(createResp.Volume.Metadata.Id))
 			Expect(json.Unmarshal(oMap[createResp.Volume.Metadata.Id], image)).NotTo(HaveOccurred())
@@ -152,7 +152,7 @@ var _ = Describe("Create Volume", func() {
 		By("ensuring the correct image has been created inside the ceph cluster with encryption header")
 		image := &api.Image{}
 		Eventually(ctx, func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", createResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", createResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(createResp.Volume.Metadata.Id))
 			Expect(json.Unmarshal(oMap[createResp.Volume.Metadata.Id], image)).NotTo(HaveOccurred())
@@ -236,7 +236,7 @@ var _ = Describe("Create Volume", func() {
 		By("ensuring image has been created inside the ceph cluster")
 		image := &api.Image{}
 		Eventually(ctx, func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", createResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", createResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(createResp.Volume.Metadata.Id))
 			Expect(json.Unmarshal(oMap[createResp.Volume.Metadata.Id], image)).NotTo(HaveOccurred())
@@ -282,7 +282,7 @@ var _ = Describe("Create Volume", func() {
 		By("ensuring snapshot has been created in snapshot store")
 		snapshot := &api.Snapshot{}
 		Eventually(ctx, func() *api.Snapshot {
-			oMap, err := ioctx.GetOmapValues(omap.NameSnapshots, "", snapshotID, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameSnapshots, "", snapshotID, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(snapshotID))
 			Expect(json.Unmarshal(oMap[snapshotID], snapshot)).NotTo(HaveOccurred())
@@ -336,7 +336,7 @@ var _ = Describe("Create Volume", func() {
 		By("ensuring image has been created inside the ceph cluster")
 		volImage := &api.Image{}
 		Eventually(ctx, func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", volCreateResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", volCreateResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(volCreateResp.Volume.Metadata.Id))
 			Expect(json.Unmarshal(oMap[volCreateResp.Volume.Metadata.Id], volImage)).NotTo(HaveOccurred())

--- a/tests/integration/volume_delete_integration_test.go
+++ b/tests/integration/volume_delete_integration_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Delete Volume", func() {
 		By("ensure the correct image has been created inside the ceph cluster")
 		image := &api.Image{}
 		Eventually(func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", createResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", createResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(createResp.Volume.Metadata.Id))
 			Expect(json.Unmarshal(oMap[createResp.Volume.Metadata.Id], image)).NotTo(HaveOccurred())
@@ -75,7 +75,7 @@ var _ = Describe("Delete Volume", func() {
 
 		By("ensuring the image has been deleted inside the ceph cluster")
 		Eventually(func() {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", createResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", createResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).NotTo(HaveKey(createResp.Volume.Metadata.Id))
 		})

--- a/tests/integration/volume_expand_integration_test.go
+++ b/tests/integration/volume_expand_integration_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Expand Volume", func() {
 		By("ensuring the correct image has been created inside the ceph cluster")
 		image := &api.Image{}
 		Eventually(func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", createResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", createResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(createResp.Volume.Metadata.Id))
 			Expect(json.Unmarshal(oMap[createResp.Volume.Metadata.Id], image)).NotTo(HaveOccurred())
@@ -122,7 +122,7 @@ var _ = Describe("Expand Volume", func() {
 
 		By("ensuring image size has been updated inside the ceph cluster after expand")
 		Eventually(func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", createResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", createResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(createResp.Volume.Metadata.Id))
 			Expect(json.Unmarshal(oMap[createResp.Volume.Metadata.Id], image)).NotTo(HaveOccurred())

--- a/tests/integration/volume_list_integration_test.go
+++ b/tests/integration/volume_list_integration_test.go
@@ -38,7 +38,7 @@ var _ = Describe("List Volume", func() {
 		By("ensuring the correct image has been created inside the ceph cluster")
 		image := &api.Image{}
 		Eventually(func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", createResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", createResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(createResp.Volume.Metadata.Id))
 			Expect(json.Unmarshal(oMap[createResp.Volume.Metadata.Id], image)).NotTo(HaveOccurred())

--- a/tests/integration/volume_status_integration_test.go
+++ b/tests/integration/volume_status_integration_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Volume Status", func() {
 		By("ensuring correct iops and tps/bps in Ceph cluster image specs")
 		image := &api.Image{}
 		Eventually(func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", createResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", createResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(createResp.Volume.Metadata.Id))
 			Expect(json.Unmarshal(oMap[createResp.Volume.Metadata.Id], image)).NotTo(HaveOccurred())

--- a/tests/integration/volumesnapshot_create_integration_test.go
+++ b/tests/integration/volumesnapshot_create_integration_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Create VolumeSnapshot", func() {
 		By("ensuring image has been created in volumes store")
 		image := &api.Image{}
 		Eventually(ctx, func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", createResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", createResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(createResp.Volume.Metadata.Id))
 			Expect(json.Unmarshal(oMap[createResp.Volume.Metadata.Id], image)).NotTo(HaveOccurred())
@@ -85,7 +85,7 @@ var _ = Describe("Create VolumeSnapshot", func() {
 		By("ensuring snapshot has been created in snapshot store")
 		snapshot := &api.Snapshot{}
 		Eventually(ctx, func() *api.Snapshot {
-			oMap, err := ioctx.GetOmapValues(omap.NameSnapshots, "", snapshotID, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameSnapshots, "", snapshotID, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(snapshotID))
 			Expect(json.Unmarshal(oMap[snapshotID], snapshot)).NotTo(HaveOccurred())

--- a/tests/integration/volumesnapshot_delete_integration_test.go
+++ b/tests/integration/volumesnapshot_delete_integration_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Delete VolumeSnapshot", func() {
 		By("ensuring image has been created in volumes store")
 		image := &api.Image{}
 		Eventually(ctx, func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", createResp.Volume.Metadata.Id, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", createResp.Volume.Metadata.Id, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(createResp.Volume.Metadata.Id))
 			Expect(json.Unmarshal(oMap[createResp.Volume.Metadata.Id], image)).NotTo(HaveOccurred())
@@ -81,7 +81,7 @@ var _ = Describe("Delete VolumeSnapshot", func() {
 		By("ensuring snapshot has been created in snapshot store")
 		snapshot := &api.Snapshot{}
 		Eventually(ctx, func() *api.Snapshot {
-			oMap, err := ioctx.GetOmapValues(omap.NameSnapshots, "", snapshotID, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameSnapshots, "", snapshotID, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(snapshotID))
 			Expect(json.Unmarshal(oMap[snapshotID], snapshot)).NotTo(HaveOccurred())
@@ -128,7 +128,7 @@ var _ = Describe("Delete VolumeSnapshot", func() {
 
 		By("ensuring the image has been deleted from snapshot store")
 		Eventually(func() {
-			oMap, err := ioctx.GetOmapValues(omap.NameSnapshots, "", snapshotID, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameSnapshots, "", snapshotID, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).NotTo(HaveKey(snapshotID))
 		})

--- a/tests/integration/volumesnapshot_list_integration_test.go
+++ b/tests/integration/volumesnapshot_list_integration_test.go
@@ -37,7 +37,7 @@ var _ = Describe("List VolumeSnapshot", func() {
 		By("ensuring the image has been created in volumes store")
 		image := &api.Image{}
 		Eventually(func() *api.Image {
-			oMap, err := ioctx.GetOmapValues(omap.NameVolumes, "", volumeId, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameVolumes, "", volumeId, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(volumeId))
 			Expect(json.Unmarshal(oMap[volumeId], image)).NotTo(HaveOccurred())
@@ -69,7 +69,7 @@ var _ = Describe("List VolumeSnapshot", func() {
 		By("ensuring snapshot has been created in snapshot store")
 		snapshot := &api.Snapshot{}
 		Eventually(ctx, func() *api.Snapshot {
-			oMap, err := ioctx.GetOmapValues(omap.NameSnapshots, "", snapshotID, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameSnapshots, "", snapshotID, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(snapshotID))
 			Expect(json.Unmarshal(oMap[snapshotID], snapshot)).NotTo(HaveOccurred())
@@ -117,7 +117,7 @@ var _ = Describe("List VolumeSnapshot", func() {
 		By("ensuring snapshot has been created in snapshot store")
 		snapshot1 := &api.Snapshot{}
 		Eventually(ctx, func() *api.Snapshot {
-			oMap, err := ioctx.GetOmapValues(omap.NameSnapshots, "", snapshotID, 10)
+			oMap, err := ioctx.GetOmapValues(omap.LegacyNameSnapshots, "", snapshotID, 10)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oMap).To(HaveKey(snapshotID))
 			Expect(json.Unmarshal(oMap[snapshotID], snapshot1)).NotTo(HaveOccurred())


### PR DESCRIPTION
# Proposed Changes

This PR contains a refactoring of the `api` and `internal/controllers` packages. The goal of this refactoring is to simplify the reconcile loops of the controller and make them more maintainable.

Fixes #833

# Work in Progress

This PR is still WIP. The refactored packages live inside `v2` sub-packages. Before merging, the refactored code must replace the original main package. 

It must be decided how to handle old and new API types. Should both co-exist, old types be migrated to the new format or should old types be dropped without migration path?